### PR TITLE
Experimental test runner around `node --test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,18 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'  # only if package-lock is present
+
     - run: npm ci
-    - run: npm run test
-    - run: npm run test:jest
-    - run: npm run test:mocha
+
+    - name: Node
+      run: npm run test
+
+    - name: Jest
+      run: npm run test:jest
+
+    - name: Mocha
+      run: npm run test:mocha
+
+    - name: Chest
+      if: runner.os != 'Windows'
+      run: npm run test:chest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [0.1.3] - tbd
+## [0.2.0] - tbd
 
-### Added
+### Changed
+
+- `@sap/cds` 8.8.0 is required at the minimum
 
 ## [0.1.2] - 2025-02-21
 

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+module.exports = Object.assign ( test, {
+  options: [
+    '--files',
+    '--include',
+    '--exclude',
+    '--pattern',
+    '--skip',
+  ],
+  flags: [
+    '--verbose',
+    '--unmute',
+    '--silent',
+    '--quiet',
+    '--list',
+    '--recent',
+    '--passed',
+    '--failed',
+  ],
+  shortcuts: [ '-f', '-i', '-x', '-p', null, '-v', '-u', '-s', '-q', '-l' ],
+  help: `
+`})
+
+
+/* eslint-disable no-console */
+const { DIMMED, RESET } = require('@sap/cds').utils.colors
+
+async function test (argv,o) {
+  if (process.platform === 'win32') throw `This runner is not supported on Windows`
+
+  const _recent = require('os').userInfo().homedir + '/.cds-test-recent.json'
+  const recent = require('fs').existsSync(_recent) ? require(_recent) : {}
+  if (!o.recent) {
+    o.files = await find (argv, o, recent)
+  } else {
+    Object.assign (o,recent.options)
+    console.log ('\nchest',...o.argv)
+  }
+  if (o.list) return list (o.files)
+  if (o.skip) process.env._chest_skip = o.skip
+  if (o.files.length > 1) console.log(DIMMED,`\nRunning ${o.files.length} test suite${o.files.length > 1 ? 's' : ''}...`, RESET)
+  const test = require('node:test').run({ ...o, concurrency:true })
+  require('../lib/reporter')(test, test.options = o)
+}
+
+
+async function find (argv,o,recent) {
+
+  // pre-process options
+  const { pattern = '.spec.js,.test.js', include, exclude = '_out' } = o,
+    patterns = pattern?.split(',') || [],
+    includes = include?.split(',') || [],
+    excludes = exclude?.split(',') || []
+
+  // return recent results if --passed or --failed is used
+  if (o.passed) return recent.passed
+  if (o.failed) return recent.failed
+
+  // check if argv is a list of files or directories
+  const {lstat} = require('fs').promises, files=[], roots=[]
+  await Promise.all (argv.map (async x => {
+    let ls = await lstat(x).catch(()=>{})
+    if (!ls) return includes.push(x)
+    if (ls.isDirectory()) return roots.push(x.replace(/\/$/,''))
+    if (ls.isFile()) return files.push(x)
+    else return includes.push(x)
+  }))
+  if (files.length && !roots.length && !includes.length) return files //> all files resolved
+
+  // Prepare UNIX find command to fetch matching files
+  let find = `find -L ${roots.join(' ')||'.'} -type f`
+  if (patterns.length) find += ` \\( ${ patterns.map (p=>`-name "${p.replace(/^([^*])/,'*$1')}"`).join(' -o ') } \\)`
+  if (includes.length) find += ` \\( ${ includes.map (p=>`-regex .*${p.replace(/\./g,'\\\\.')}.*`).join(' -o ') } \\)`
+  if (excludes.length) find += ` \\( ${ excludes.map (x=>`! -regex .*${x.replace(/\./g,'\\\\.')}.*`).join(' ') } \\)`
+
+  // Execute find command and return list of files
+  const exec = require('node:util') .promisify (require('node:child_process').exec)
+  const { stdout } = await exec (find)
+  return files.concat (stdout.split('\n').slice(0, -1).sort())
+}
+
+
+function list (files) {
+  const { relative } = require('node:path'), cwd = process.cwd()
+  console.log()
+  console.log(`Found ${files.length} test file${files.length > 1 ? 's' : ''}:`, DIMMED, '\n')
+  for (let f of files) console.log('  ', relative(cwd, f))
+  console.log(RESET)
+}
+
+
+if (!module.parent) {
+  // TODO replace w/ common arg parser from node or cds API
+  const [ argv, options ] = require('@sap/cds/bin/args') (test, process.argv.slice(2))
+  test (argv, options).catch(err => {
+    console.error(err)
+    process.exitCode = 1
+  })
+}

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -1,9 +1,7 @@
-const { BRIGHT, BOLD, INVERT, GRAY, GREEN, RESET, LF='\n', DIMMED } = require('@sap/cds').utils.colors
-const YELLOW = '\x1b[38;5;220m'
-const RED = '\x1b[38;5;160m'
+const { BRIGHT, BOLD, INVERT, GRAY, GREEN, RESET, LF='\n', DIMMED, YELLOW, RED } = require('@sap/cds').utils.colors
 const PASS = '\x1b[38;5;244m'
 const FAIL = '\x1b[38;5;244m' // '\x1b[38;5;124m'
-const SKIP = RESET+DIMMED // '\x1b[38;5;244m' // '\x1b[38;5;124m'
+const SKIP = RESET+DIMMED
 const { inspect } = require('node:util')
 /* eslint-disable no-console */
 
@@ -47,8 +45,8 @@ module.exports = function report_on (test,o) {
       let msg = typeof err === 'string' ? err : inspect (err, { colors:true, depth:11 })
       console.log(RESET)
       console.log(msg
-        .replace(/\n.*cds\/lib\/test\/expect.js:.*\)/g,'')
-        .replace(/\n.*\(node:.*/g,'')
+        .replace(/\s+.*lib\/expect\.js:.*\)/g,'')
+        .replace(/\s+.*\(node:.*/g,'')
         .replace(/^/gm, _indent4(x)+'  ')
       )
       if (!err.message && !o.unmute)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cap-js/cds-test",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cds-test",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "axios": "^1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-test",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Test Support for CAP Node.js",
   "keywords": [
     "CAP",
@@ -13,7 +13,12 @@
   },
   "homepage": "https://cap.cloud.sap/",
   "main": "index.js",
+  "bin": {
+    "cds-test": "bin/test.js",
+    "chest": "bin/test.js"
+  },
   "files": [
+    "bin/",
     "lib/",
     "index.js"
   ],
@@ -21,9 +26,10 @@
     "node": ">=20"
   },
   "scripts": {
-    "test": "node --test \"**/*.test.js\"",
-    "test:jest": "npx -y jest",
-    "test:mocha": "npx -y mocha \"test/**/*.test.js\""
+    "test": "node --test \"test/**/*.test.js\"",
+    "test:mocha": "npx -y mocha \"test/**/*.test.js\"",
+    "test:jest": "npx -y jest \"test/.*\\.test\\.js\"",
+    "test:chest": "cds-test test"
   },
   "dependencies": {
     "axios": "^1",


### PR DESCRIPTION
From the original PR in cap/cds#4272:
- An enhancement to `cds.test` to support [Node's native `node --test` runner](https://nodejs.org/api/test.html) as an alternative to Jest and Mocha
- A new `cds test` (alias `chest`) CLI command as a better alternative to using `node --test`
- A custom test reporter that produces nicer output, than the one shipped with `node --test`
- A new implementation for `expect` command that supports Chai APIs as well as Jest APIs

Not working on Windows for now.