### PR TITLE
fix: catch data reset errors

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -5,7 +5,7 @@ class DataUtil {
   constructor() {
     // This is to support simplified usage like that: beforeEach(test.data.reset)
     const {reset} = this; this.reset = (x) => {
-      if (typeof x === 'function') reset.call(this).then(x) // x is the done callback of jest -> no return
+      if (typeof x === 'function') reset.call(this).then(x,x) // x is the done callback of jest -> no return
       else if (x?.assert) return reset.call(this) // x is a node --test TestContext object -> ignore
       else return reset.call(this,x) // x is a db service instance
     }


### PR DESCRIPTION
Currently when the `cds.data.reset` functions `throws` it will never call the `done` callback. By adding the callback an extra time it is also attached as the `catch` handler. This prevents `jest` and `mocha` from giving random `timeout` errors. In the case of `node --test` this will prevent the test from handing indefinitely. Instead the original `Error` will be provided as failure reason.