### PR TITLE
test: remove relative self references

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "chest": "bin/test.js"
       },
       "devDependencies": {
+        "@cap-js/cds-test": "file://.",
         "@cap-js/sqlite": "^1.5.0",
+        "@cap-js/test-sample-app": "file://./test/app/",
         "@sap/cds": "^8.8",
         "express": "^4.17.1"
       },
@@ -28,6 +30,20 @@
       },
       "peerDependencies": {
         "@sap/cds": ">=8.8"
+      }
+    },
+    "node_modules/@cap-js/cds-test": {
+      "resolved": "",
+      "link": true
+    },
+    "node_modules/@cap-js/cds-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/cds-types/-/cds-types-0.2.0.tgz",
+      "integrity": "sha512-s4iVwAjf+rRIUu6jaEooXFcJv16+sP5CTkreQPxDUyxLWWGlhvEr67TuIH0C6Cnp4PPIsYmBK3AVxSW2mNc2wg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "peerDependencies": {
+        "@sap/cds": ">=7"
       }
     },
     "node_modules/@cap-js/db-service": {
@@ -56,6 +72,14 @@
       "peerDependencies": {
         "@sap/cds": ">=7.6"
       }
+    },
+    "node_modules/@cap-js/test": {
+      "resolved": "",
+      "link": true
+    },
+    "node_modules/@cap-js/test-sample-app": {
+      "resolved": "test/app",
+      "link": true
     },
     "node_modules/@sap/cds": {
       "version": "8.8.0",
@@ -1737,6 +1761,55 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "test/app": {
+      "name": "@cap-js/test-sample-app",
+      "dev": true,
+      "dependencies": {
+        "@sap/cds": "^7"
+      },
+      "devDependencies": {
+        "@cap-js/sqlite": "^1.5.0",
+        "@cap-js/test": "file:../.."
+      }
+    },
+    "test/app/node_modules/@sap/cds": {
+      "version": "7.9.5",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.9.5.tgz",
+      "integrity": "sha512-DNCpXWhwZzIShqjoxOTW9cyYB/mE8k/7d+lSp1BCRLnc30R2vEU0ScqZVngjIZfQFRKWkLePy9/FulAEhqv+wQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@cap-js/cds-types": "<=0.2.0",
+        "@sap/cds-compiler": "^4",
+        "@sap/cds-fiori": "^1",
+        "@sap/cds-foss": "^5.0.0"
+      },
+      "bin": {
+        "cds-deploy": "lib/dbs/cds-deploy.js",
+        "cds-serve": "bin/cds-serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "test/app/node_modules/@sap/cds-compiler": {
+      "version": "4.9.8",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.9.8.tgz",
+      "integrity": "sha512-DaodIJoYPpVygVf+9JU6XNW+WLDqX1sHklpj8qkrONLxM6G1TFBm5yrAT0P2YCibgNsGVhizA4eydgoHnVxUVQ==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "antlr4": "4.9.3"
+      },
+      "bin": {
+        "cdsc": "bin/cdsc.js",
+        "cdshi": "bin/cdshi.js",
+        "cdsse": "bin/cdsse.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1767,49 +1767,11 @@
       "name": "@cap-js/test-sample-app",
       "dev": true,
       "dependencies": {
-        "@sap/cds": "^7"
+        "@sap/cds": "^8"
       },
       "devDependencies": {
         "@cap-js/sqlite": "^1.5.0",
         "@cap-js/test": "file:../.."
-      }
-    },
-    "test/app/node_modules/@sap/cds": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-7.9.5.tgz",
-      "integrity": "sha512-DNCpXWhwZzIShqjoxOTW9cyYB/mE8k/7d+lSp1BCRLnc30R2vEU0ScqZVngjIZfQFRKWkLePy9/FulAEhqv+wQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@cap-js/cds-types": "<=0.2.0",
-        "@sap/cds-compiler": "^4",
-        "@sap/cds-fiori": "^1",
-        "@sap/cds-foss": "^5.0.0"
-      },
-      "bin": {
-        "cds-deploy": "lib/dbs/cds-deploy.js",
-        "cds-serve": "bin/cds-serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "test/app/node_modules/@sap/cds-compiler": {
-      "version": "4.9.8",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-4.9.8.tgz",
-      "integrity": "sha512-DaodIJoYPpVygVf+9JU6XNW+WLDqX1sHklpj8qkrONLxM6G1TFBm5yrAT0P2YCibgNsGVhizA4eydgoHnVxUVQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "antlr4": "4.9.3"
-      },
-      "bin": {
-        "cdsc": "bin/cdsc.js",
-        "cdshi": "bin/cdshi.js",
-        "cdsse": "bin/cdsse.js"
-      },
-      "engines": {
-        "node": ">=16"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@sap/cds": ">=8.8"
   },
   "devDependencies": {
+    "@cap-js/cds-test": "file://.",
+    "@cap-js/test-sample-app": "file://./test/app/",
     "@cap-js/sqlite": "^1.5.0",
     "@sap/cds": "^8.8",
     "express": "^4.17.1"

--- a/test/app/package.json
+++ b/test/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cap-js/test-sample-app",
   "dependencies": {
-    "@sap/cds": "^7"
+    "@sap/cds": "^8"
   },
   "devDependencies": {
     "@cap-js/test": "file:../..",

--- a/test/app/srv/cat-service.js
+++ b/test/app/srv/cat-service.js
@@ -1,7 +1,7 @@
 const cds = require('@sap/cds')
 
 class CatalogService extends cds.ApplicationService { init(){
-  const { Books } = cds.entities ('sap.capire.bookshop')
+  const { Books } = this.entities
 
   // Reduce stock of ordered books if available stock suffices
   this.on ('submitOrder', async req => {

--- a/test/app/test/sample-bookshop.test.js
+++ b/test/app/test/sample-bookshop.test.js
@@ -1,11 +1,11 @@
-const cds_test = require ('../../..')
+const cds_test = require('@cap-js/cds-test')
 const describe = global.describe ?? require('node:test').describe
 
 describe('Sample tests', () => {
-  const { GET, expect } = cds_test (__dirname+'/..')
+  const { GET, expect } = cds_test('@cap-js/test-sample-app')
 
   it('serves Books', async () => {
-    const { data } = await GET `/odata/v4/catalog/Books`
+    const { data } = await GET`/odata/v4/catalog/Books`
     expect(data.value.length).to.be.greaterThanOrEqual(5)
   })
 

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 const cds = require ('@sap/cds')
-const cds_test = require ('..')
+const cds_test = require ('@cap-js/cds-test')
 const Books = 'sap.capire.bookshop.Books'
 const describe = global.describe ?? require('node:test').describe
 
@@ -138,7 +138,7 @@ describe('cds_test', ()=>{
 
     it('data reset should be draft aware', async()=> {
       const { data } = test
-      const { Books } = cds.services['DraftService'].entities
+      const { Books } = cds.entities('DraftService')
       const db = await cds.connect.to('db')
       expect(await db.run(SELECT.from(Books.drafts))).not.to.be.empty
 

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-const expect = require('../lib/expect')
+const expect = require('@cap-js/cds-test/lib/expect')
 const describe = global.describe ?? require('node:test').describe
 const it = global.it ?? require('node:test').it
 


### PR DESCRIPTION
By adding the relative `file://.` devdependecies it is possible inside the tests to reference the package itself by name. Additionally adding the test application allows the testing of `cds_test('@cap-js/test-sample-app')` which is the recommended way for application writing their own tests.