### PR TITLE
feat: performance measurement APIs

### DIFF
--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -11,6 +11,7 @@ class Test extends require('./axios') {
   get cds() { return require('@sap/cds') }
   get sleep() { return super.sleep = require('util').promisify(setTimeout) }
   get data() { return super.data = new (require('./data'))}
+  get perf() { return super.perf = new (require('./perf'))(this)}
 
   /**
    * Launches a cds server with arbitrary port and returns a subclass which

--- a/lib/perf.js
+++ b/lib/perf.js
@@ -1,0 +1,196 @@
+const cds = require('@sap/cds')
+const { LIGHT_GRAY: GREEN, DIMMED, RESET } = require('@sap/cds/lib/utils/colors')
+
+const DEFAULTS = {
+  warmup: {
+    duration: '1s',
+  },
+  duration: '3s',
+  connections: 3,
+}
+
+class Performance {
+  constructor(test) {
+    this._test = test
+    this._reports = 0
+  }
+
+  get autocannon() {
+    const autocannon = require('autocannon')
+    super._histUtil = require('autocannon/lib/histUtil')
+    super._aggregateResult = require('autocannon/lib/aggregateResult')
+    super._timestring = require('timestring')
+    return super.autocannon = autocannon
+  }
+  fn(..._) { return this._run(this._args('FN', _)) }
+  get(..._) { return this.autocannon(this._args('GET', _)) }
+  put(..._) { return this.autocannon(...this._args('PUT', _)) }
+  post(..._) { return this.autocannon(...this._args('POST', _)) }
+  patch(..._) { return this.autocannon(...this._args('PATCH', _)) }
+  delete(..._) { return this.autocannon(...this._args('DELETE', _)) }
+  options(..._) { return this.autocannon(...this._args('OPTIONS', _)) }
+
+  /** @type typeof _.options */ get FN() { return this.fn.bind(this) }
+  /** @type typeof _.get     */ get GET() { return this.get.bind(this) }
+  /** @type typeof _.put     */ get PUT() { return this.put.bind(this) }
+  /** @type typeof _.post    */ get POST() { return this.post.bind(this) }
+  /** @type typeof _.patch   */ get PATCH() { return this.patch.bind(this) }
+  /** @type typeof _.delete  */ get DELETE() { return this.delete.bind(this) }
+  /** @type typeof _.delete  */ get DEL() { return this.delete.bind(this) } //> to avoid conflicts with cds.ql.DELETE
+  /** @type typeof _.options */ get OPTIONS() { return this.options.bind(this) }
+
+  _args(METHOD, args) {
+    const first = args[0], last = args[args.length - 1]
+    if (first.raw) {
+      if (first[first.length - 1] === '' && typeof last === 'object')
+        return this._defaults(METHOD, last, { url: String.raw(...args.slice(0, -1)) })
+      return this._defaults(METHOD, { url: String.raw(...args) })
+    }
+    else if (typeof first === 'string') args[0] = { url: first }
+    else if (typeof first === 'function') args[0] = { fn: first, title: first.name }
+    else if (typeof first !== 'string')
+      throw new Error(`Argument path is expected to be a string or function but got ${typeof first}`)
+    return this._defaults(METHOD, ...args)
+  }
+
+  _defaults(method = 'GET', ...opts) {
+    let fn
+    if (typeof method === 'function') fn = method
+
+    const o = Object.assign({ fn, method }, DEFAULTS, ...opts)
+    if (o.url) {
+      o.title ??= o.url
+      const { auth } = this._test.axios.defaults
+      o.headers ??= {}
+      if (auth) {
+        o.headers.authorization = `Basic ${btoa(`${auth.username}:${auth.password}`)}`
+      }
+      const { baseURL } = this._test.axios.defaults || ''
+      const sep = baseURL.at(-1) !== '/' && o.url?.[0] !== '/' ? '/' : ''
+      o.url = /^https?:/.test(o.url) ? o.url : `${baseURL}${sep}${o.url}`
+    }
+    return o
+  }
+
+  async _run(opts) {
+    this.autocannon
+
+    let { fn, args } = opts
+    if (args) fn = fn.bind(null, ...args)
+
+    if (opts.warmup) await this._run({ ...opts, fn, args: undefined, ...opts.warmup, warmup: undefined })
+
+    const { getHistograms, encodeHist } = this._histUtil
+
+    const histograms = getHistograms(opts.histograms)
+    const { latencies, requests, throughput } = histograms
+
+    const statusCodeStats = {}
+
+    let stop = false
+    let count = 0
+    let errors = 0
+    let nextTrack
+    let totalRequests = 0
+    let totalCompletedRequests = 0
+
+    const runners = new Array(opts.connections)
+
+    const startTime = process.hrtime.bigint()
+    const endTime = startTime + BigInt((typeof opts.duration === 'string' ? this._timestring(opts.duration) : opts.duration) * 1e9)
+
+    for (let r = 0; r < runners.length; r++) {
+      runners[r] = run()
+    }
+    await Promise.all(runners)
+
+    const result = {
+      latencies: encodeHist(latencies),
+      requests: encodeHist(requests),
+      throughput: encodeHist(throughput),
+      totalCompletedRequests,
+      totalRequests,
+      totalBytes: 0,
+      samples: Math.floor(Number(process.hrtime.bigint() - startTime) / 1e9),
+      errors,
+      timeouts: 0,
+      mismatches: 0,
+      non2xx: Object.keys(statusCodeStats).reduce((l, c) => l + (c[0] === '2' ? 0 : statusCodeStats[c]), 0),
+      statusCodeStats,
+      resets: 0,
+      duration: Number(process.hrtime.bigint() - startTime) / 1e9,
+      start: new Date(Number(startTime)),
+      finish: new Date(),
+      '1xx': 0,
+      '2xx': statusCodeStats['200']?.count || 0,
+      '3xx': 0,
+      '4xx': 0,
+      '5xx': statusCodeStats['500']?.count || 0,
+    }
+
+    return this._aggregateResult(result, opts, histograms)
+
+    async function run() {
+      while (!stop) {
+        const now = process.hrtime.bigint()
+        if (!nextTrack) nextTrack = now + BigInt(1e9)
+        if (now >= nextTrack) {
+          nextTrack = now + BigInt(1e9)
+          requests.recordValue(count)
+          count = 0
+        }
+
+        if (now >= endTime) {
+          stop = true
+          break
+        }
+
+        totalRequests++
+        try {
+          const s = process.hrtime.bigint()
+
+          const ret = fn()
+          if (ret?.then) await ret;
+
+          const d = process.hrtime.bigint() - s
+          latencies.recordValue(Number(d) / 1000000)
+
+          count++
+          totalCompletedRequests++
+          (statusCodeStats['200'] ??= { count: 0 }).count++
+        } catch {
+          errors++
+          (statusCodeStats['500'] ??= { count: 0 }).count++
+        }
+      }
+    }
+  }
+
+  async _report(result, options = {}) {
+    let { requests, latency, throughput, title = `${this._reports++}` } = result
+
+    // Collect the result into a file for further processing later
+    if (options.store) {
+      result.file = cds.utils.path.relative(process.cwd(), require.main.filename)
+      const stack = {}
+      Error.captureStackTrace(stack)
+      result.line = /:(\d*:\d*)\)/.exec(stack.stack.split('\n').find(l => l.indexOf(result.file) > -1))?.[1]
+
+      const benchmark = `${result.file}:${title}`
+      cds.utils.fs.writeFileSync(cds.utils.path.resolve(process.cwd(), 'results.bench'), `${JSON.stringify({ [benchmark]: result })}\n`, { flag: 'a' })
+    }
+
+    // TODO: determine a good default report format of the available measured information
+    console.log( // eslint-disable-line no-console
+      title.padEnd(50),
+      GREEN + (requests.average >>> 0).toLocaleString().padStart(5), DIMMED + 'req/s' + RESET,
+      GREEN + (throughput.average / 1024 / 1024 >>> 0).toLocaleString().padStart(5), DIMMED + 'MiB/s' + RESET,
+      GREEN + (latency.average >>> 0).toLocaleString().padStart(5), DIMMED + 'ms' + RESET,
+    )
+  }
+  /** @type typeof _._report */ get report() { return this._report.bind(this) }
+
+}
+
+// ? const _ = Performance.prototype // eslint-disable-line no-unused-vars
+module.exports = Performance

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:node": "node --test"
   },
   "dependencies": {
+    "autocannon": "^8.0.0",
     "axios": "^1",
     "chai": "^4.4.1",
     "chai-as-promised": "^7.1.1",

--- a/test/app/test/sample-bookshop.test.js
+++ b/test/app/test/sample-bookshop.test.js
@@ -2,11 +2,15 @@ const cds_test = require('../../../lib/cds-test')
 const describe = global.describe ?? require('node:test').describe
 
 describe('Sample tests', () => {
-  const { GET, expect } = cds_test(__dirname+'/..')
+  const { GET, expect, perf } = cds_test(__dirname+'/..')
 
   it('serves Books', async () => {
     const { data } = await GET`/odata/v4/catalog/Books`
     expect(data.value.length).to.be.greaterThanOrEqual(5)
+  })
+
+  it('measures Books', async () => {
+    perf.report(await perf.GET `/odata/v4/catalog/Books`)
   })
 
 })

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -91,6 +91,27 @@ describe('cds_test', ()=>{
     })
   })
 
+  describe ('perf', ()=> {
+    it('should support perf', ()=> {
+      expect (test.perf).to.exist
+      const { perf } = test
+      expect (perf.get).to.exist
+      expect (perf.put).to.exist
+      expect (perf.post).to.exist
+      expect (perf.delete).to.exist
+      expect (perf.fn).to.exist
+    })
+
+    it('should support REST shortcuts', ()=> {
+      const { GET,PUT,POST,PATCH,DEL,FN} = test.perf
+      expect (GET).to.exist
+      expect (PUT).to.exist
+      expect (POST).to.exist
+      expect (PATCH).to.exist
+      expect (DEL).to.exist
+      expect (FN).to.exist
+    })
+  })
 
   describe ('logs', ()=> {
 


### PR DESCRIPTION
This PR adds a new `perf` property to the `cds.test` API. Which is a wrapper around the commonly used `autocannon` node module. Which allows developers to measure the performance of their endpoints. To make the API as simple to use as possible the APIs have `axios` integration. Which means that by default the same base `url` is used by `perf` as it currently used by `axios`.

Additionally `perf` introduces the `fn` API. Which accepts a callback function which will be measured in a similar way as all the `autocannon` APIs are. Providing flexibility for not just measuring http request performance, but also for measuring the performance of any javascript function. For the use cases where multiple requests have to be chained together the `fn` callback can be `async` and the promise will be awaited and the `connections` configuration of `autocannon` will apply so that if there `async` function detaches from the event loop. It will trigger multiple parallel calls to the callback function.

```javascript
const { POST, DELETE, perf: {GET, report, fn} } = cds.test()

it('GET', async () => {
  report(await GET`/browse/Books`)
})

it('complex', async () => report(await fn(async () => {
  const book = await POST('/admin/Books', {})
  await DELETE`/admin/Books(${book.ID})`
}))

it('compute', async () => report(await fn(() => {
  cds.db.cqn2sql(cds.ql`SELECT * FROM Books`)
})))

```