### PR TITLE
feat: using excludes from jest.configs

### DIFF
--- a/bin/chest.js
+++ b/bin/chest.js
@@ -75,7 +75,7 @@ async function test (argv,o) {
 
 async function fetch (argv,o) {
   if (o.match) o.include = o.match
-  if (o.exclude === 'jest.config') o.exclude = jest().exclude
+  if (o.exclude === 'jest.config') o.exclude = jest().testPathIgnorePatterns?.join('|') || o.exclude
   const patterns = regex4 (argv.join('|')) || { test: ()=> true }
   const include = regex4 (o.include || options.include.default) || { test: ()=> true }
   const exclude = regex4 (o.exclude || options.exclude.default) || { test: ()=> false }
@@ -112,9 +112,9 @@ function jest() {
     if (exists (config_js+ext)) {
       // IMPORTANT: We need to jun that in a separate process to avoid loading the cds.env in current process
       const { stdout } = require('node:child_process').spawnSync (
-        'node',  [ '-e', `console.log(require('${config_js+ext}').testPathIgnorePatterns?.join('|')||'')` ]
+        'node',  [ '-e', `console.log(JSON.stringify(require('${config_js+ext}')))` ]
       , { encoding: 'utf-8' })
-      return { exclude: stdout }
+      return JSON.parse (stdout)
     }
   }
   return console.warn ('No jest.config found, skipping testPathIgnorePatterns')

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -11,9 +11,11 @@ const options = {
   'recent':   { type:'boolean' },
   'passed':   { type:'boolean' },
   'failed':   { type:'boolean' },
-  'match':    { type:'string', default: '(.test.js|.spec.js)$' },
-  'skip':     { type:'string', default: '^(gen,*.tmp)$' },
-  'only':     { type:'string'},
+  'match':    { type:'string' },
+  'include':  { type:'string', short:'i', default: '(.test.js|.spec.js)$' },
+  'exclude':  { type:'string', short:'x', _default: '^(gen,*.tmp)$' },
+  'only':     { type:'string', short:'o', },
+  'skip':     { type:'string', short:'n', },
   'workers':  { type:'string', short:'w' },
   'debug':    { type:'string' },
   'help':     { type:'boolean', short:'h' },
@@ -27,6 +29,10 @@ Usage:
 Options:
 
   -l, --list     List found test files
+  -i, --include  Include matching files, default: ${options.include.default}
+  -x, --exclude  Exclude matching files, default: ${options.exclude.default}
+  -n, --skip     Skip all matching test cases
+  -o, --only     Run only matching test cases
   -q, --quiet    No output at all
   -s, --silent   No output
   -t, --timeout  in milliseconds
@@ -34,19 +40,19 @@ Options:
   -v, --verbose  Increase verbosity
   -w, --workers  Specify number of workers
   -?, --help     Displays this usage info
-
-  --match        Pick matching files, default: ${options.match.default}
-  --skip         Skip matching files, default: ${options.skip.default}
-  --only         Run only the matching tests
   --failed       Repeat recently failed test suite(s)
   --passed       Repeat recently passed test suite(s)
   --recent       Repeat recently run test suite(s)
+  --match        Alias to --include
 `
 
 const { DIMMED, YELLOW, GRAY, RESET } = require('./colors')
 const regex4 = s => !s ? null : RegExp (s.replace(/[,.*]/g, s => ({ ',': '|', '.': '\\.', '*': '.*' })[s]))
 const recent = () => {try { return require(home+'/.cds-test-recent.json') } catch {/* egal */}}
 const os = require('os'), home = os.userInfo().homedir
+const path = require('node:path')
+const fs = require('node:fs')
+const { exists } = require('@sap/cds/lib/utils')
 
 async function test (argv,o) {
   if (o.help || argv == '?') return console.log (USAGE)
@@ -61,25 +67,27 @@ async function test (argv,o) {
     execArgv: [ '--require', require.resolve('../lib/fixtures/node-test.js') ],
     timeout: +o.timeout || undefined,
     concurrency: +o.workers || true,
+    forceExit: true,
+    testSkipPatterns: regex4 (o.skip), skip: false,
     testNamePatterns: regex4 (o.only), only: false,
   })
   require('./reporter')(test, test.options = o)
 }
 
 async function fetch (argv,o) {
+  if (o.match) o.include = o.match; o.exclude ??= jest().exclude || '^(gen,*.tmp)$'
   const patterns = regex4 (argv.join('|')) || { test: ()=> true }
-  const tests = regex4 (o.match || options.match.default) || { test: ()=> true }
-  const skip = regex4 (o.skip || options.skip.default) || { test: ()=> false }
+  const include = regex4 (o.include || options.include.default) || { test: ()=> true }
+  const exclude = regex4 (o.exclude || options.exclude.default) || { test: ()=> false }
   const ignore = /^(\..*|node_modules|_out)$/
   const files = []
-  const fs = require('node:fs'), path = require('node:path')
   const _read = fs.promises.readdir
   const _isdir = x => fs.statSync(x).isDirectory()
   await async function _visit (dir) {
     const entries = await _read (dir)
     return Promise.all (entries.map (each => {
-      if (ignore.test(each) || skip.test(each = path.join (dir,each))) return
-      if (tests.test(each)) return patterns.test(each) && files.push(each)
+      if (ignore.test(each) || exclude.test(each = path.join (dir,each))) return
+      if (include.test(each)) return patterns.test(each) && files.push(each)
       if (_isdir(each)) return _visit (each)
     }))
   } (process.cwd())
@@ -97,6 +105,20 @@ function list (files) {
   console.log(GRAY, time+'s', RESET, '\n')
 }
 
+function jest() {
+  const config_js = process.cwd() + '/jest.config'
+  const exists = fs.existsSync
+  for (const ext of [ '.js', '.json', '.mjs', '.cjs' ]) {
+    if (exists (config_js+ext)) {
+      // IMPORTANT: We need to jun that in a separate process to avoid loading the cds.env in current process
+      const { stdout } = require('node:child_process').spawnSync (
+        'node',  [ '-e', `console.log(require('${config_js+ext}').testPathIgnorePatterns?.join('|')||'')` ]
+      , { encoding: 'utf-8' })
+      return { exclude: stdout }
+    }
+  }
+  return {}
+}
 
 if (!module.parent) {
   const { positionals, values } = require('node:util').parseArgs ({ options, allowPositionals: true })
@@ -106,8 +128,8 @@ if (!module.parent) {
 else module.exports = Object.assign ( test, {
   options: [
     '--files',
-    '--match',
-    '--skip',
+    '--include',
+    '--exclude',
     '--timeout',
     '--workers',
   ],
@@ -121,6 +143,6 @@ else module.exports = Object.assign ( test, {
     '--passed',
     '--failed',
   ],
-  shortcuts: [ '-f', null, null, '-t', '-w', '-v', '-u', '-s', '-q', '-l' ],
+  shortcuts: [ '-f', '-i', '-x', '-t', '-w', '-v', '-u', '-s', '-q', '-l' ],
   help: USAGE
 })

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -111,9 +111,9 @@ function jest() {
   for (const ext of [ '.js', '.json', '.mjs', '.cjs' ]) {
     if (exists (config_js+ext)) {
       // IMPORTANT: We need to jun that in a separate process to avoid loading the cds.env in current process
-      const { stdout } = require('node:child_process').spawnSync (
-        'node',  [ '-e', `console.log(JSON.stringify(require('${config_js+ext}')))` ]
-      , { encoding: 'utf-8' })
+      const { stdout } = require('node:child_process') .spawnSync ('node', [
+        '-e', `console.log( JSON.stringify (require('${config_js+ext}') ))`
+      ], { encoding: 'utf-8' })
       return JSON.parse (stdout)
     }
   }

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -13,7 +13,7 @@ const options = {
   'failed':   { type:'boolean' },
   'match':    { type:'string' },
   'include':  { type:'string', short:'i', default: '(.test.js|.spec.js)$' },
-  'exclude':  { type:'string', short:'x', _default: '^(gen,*.tmp)$' },
+  'exclude':  { type:'string', short:'x', default: '^(gen,*.tmp)$' },
   'only':     { type:'string', short:'o', },
   'skip':     { type:'string', short:'n', },
   'workers':  { type:'string', short:'w' },
@@ -52,7 +52,6 @@ const recent = () => {try { return require(home+'/.cds-test-recent.json') } catc
 const os = require('os'), home = os.userInfo().homedir
 const path = require('node:path')
 const fs = require('node:fs')
-const { exists } = require('@sap/cds/lib/utils')
 
 async function test (argv,o) {
   if (o.help || argv == '?') return console.log (USAGE)
@@ -75,7 +74,8 @@ async function test (argv,o) {
 }
 
 async function fetch (argv,o) {
-  if (o.match) o.include = o.match; o.exclude ??= jest().exclude || '^(gen,*.tmp)$'
+  if (o.match) o.include = o.match
+  if (o.exclude === 'jest.config') o.exclude = jest().exclude
   const patterns = regex4 (argv.join('|')) || { test: ()=> true }
   const include = regex4 (o.include || options.include.default) || { test: ()=> true }
   const exclude = regex4 (o.exclude || options.exclude.default) || { test: ()=> false }
@@ -117,7 +117,7 @@ function jest() {
       return { exclude: stdout }
     }
   }
-  return {}
+  return console.warn ('No jest.config found, skipping testPathIgnorePatterns')
 }
 
 if (!module.parent) {

--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -8,7 +8,7 @@ class Test extends require('./axios') {
    */
   test = this
 
-  get cds() { return require('@sap/cds') }
+  get cds() { return require('@sap/cds/lib') }
   get sleep() { return super.sleep = require('node:timers/promises').setTimeout }
   get data() { return super.data = new (require('./data'))}
 
@@ -20,29 +20,25 @@ class Test extends require('./axios') {
 
     switch (folder_or_cmd) {
       case 'serve': break // nothing to do as all arguments are given
-      case 'run': if (args.length > 0) args.unshift('--project'); break
-      default: this.in(folder_or_cmd); args.push('--in-memory?')
+      case 'run': if (args.length > 0) args.unshift ('--project'); break
+      default: this.in(folder_or_cmd); args.push ('--in-memory?')
     }
     const {cds} = this
 
     // launch cds server...
     before (async ()=>{
-      process.env.cds_test_temp = cds.utils.path.resolve(cds.root,'_out',''+process.pid)
-      if (!args.includes('--port')) args.push('--port', '0')
-      let { server, url } = await cds.exec(...args)
+      process.env.cds_test_temp = cds.utils.path.resolve (cds.root,'_out',''+process.pid)
+      if (!args.includes('--port')) args.push ('--port', '0')
+      let { server, url } = await cds.exec (...args)
       this.server = server
       this.url = url
     })
 
     // gracefully shutdown cds server...
-    after (async ()=>{
-      await cds.shutdown()
-      // cds.service.providers = []
-      // delete cds.services
-      // delete cds.plugins
-      // delete cds.env
-      await cds.utils.rimraf (process.env.cds_test_temp)
-    })
+    after (()=> Promise.all([
+      cds.utils.rimraf (process.env.cds_test_temp),
+      cds.shutdown(),
+    ]))
 
     return this
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "npm run -s test:jest",
-    "test:chest": "chest test",
+    "test:chest": "chest test -u",
     "test:jest": "npx -y jest",
     "test:mocha": "npx -y mocha",
     "test:node": "node --test"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "npm run -s test:jest",
-    "test:chest": "chest test -u",
+    "test:chest": "bin/chest.js test",
     "test:jest": "npx -y jest",
     "test:mocha": "npx -y mocha",
     "test:node": "node --test"

--- a/test/app/test/sample-bookshop.test.js
+++ b/test/app/test/sample-bookshop.test.js
@@ -1,5 +1,4 @@
 const cds_test = require('../../../lib/cds-test')
-const describe = global.describe ?? require('node:test').describe
 
 describe('Sample tests', () => {
   const { GET, expect } = cds_test(__dirname+'/..')

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -1,7 +1,5 @@
 /* eslint-disable no-console */
 const expect = require('../lib/expect')
-const describe = global.describe ?? require('node:test').describe
-const it = global.it ?? require('node:test').it
 
 describe (`supported chai features subset ...`, ()=>{
 


### PR DESCRIPTION
- `chest -x jest.config` uses `testPathIgnorePatterns` from an existing `jest.config.[cm]?js(on)?`