### PR TITLE
fix: err.cause is used in cds tests

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -63,7 +63,7 @@ const _error = (e) => {
   // Add original error thrown by the service, if exists
   const o = err.response?.data?.error ; if (!o) throw err
   err.message = !o.code || o.code == 'null' ? o.message : `${o.code} - ${o.message}`
-  // err.cause = o instanceof Error ? o : Object.assign (new Error, o)
+  err.cause = o instanceof Error ? o : Object.assign (new Error, o)
   // Object.defineProperty (o, 'stack', { enumerable:false }) //> allow strict equal checks against {code,message}
   throw err
 }


### PR DESCRIPTION
typically axios rejects with a not very detailed error message.
the more meaningful cause is found in the response payload which can also be accessed with `err.response.data.error` but was made easier accessible with `err.cause`.

I have adapted our internal usage within @sap/cds but that might already hint for a broader usage.
@chgeo do you have more insights on this?