### PR TITLE
Using fetch() API instead of Axios (opt in for canaries)

### DIFF
--- a/lib/axios.js
+++ b/lib/axios.js
@@ -1,4 +1,5 @@
-// require = id => module.require (id === 'axios' ? './naxios' : id) // eslint-disable-line no-global-assign
+const { NAXIOS } = process.env //> for early birds, aka canaries
+if (NAXIOS) require = id => module.require (id === 'axios' ? './naxios' : id) // eslint-disable-line no-global-assign
 
 class AxiosProvider {
 
@@ -49,22 +50,30 @@ const _args = (args) => {
   else throw new Error (`Argument path is expected to be a string but got ${typeof first}`)
 }
 
-const _error = (e) => {
-  if (e.errors) e = e.errors[0] // Node 20 sends AggregationErrors
-  if (e.code === 'ERR_INVALID_URL') {// URL wasn't completed due to the non-started server
-    Error.captureStackTrace(e, require('axios').Axios.prototype.request) // avoid stack clutter from Axios
-    throw new Error (`It seems that the server was not started. Make sure to call 'cds.test(...)' or 'cds.test.run(...)'.`, {cause:e})
+const _error = (err) => {
+
+  // Node 20 sends AggregationErrors -> REVISIT: is that still the case? Doesn't seem so with Node 22
+  if (err.errors) err = err.errors[0]
+
+  // If the server was not started, the URL is invalid
+  if ((err.code || err.cause?.code) === 'ERR_INVALID_URL') {
+    throw new Error (`It seems that the server was not started. Ensure to call 'cds.test(...)'.`, {cause:err})
   }
 
-  // Create new instance of Error to overcome AxiosError's inferior and cluttered output
-  const err = new Error (e.message); err.code = e.code
-  Object.defineProperty (err, 'response', { value: e.response, enumerable:false })
-  Error.captureStackTrace (err, _error)
+  // Reduce AxiosError's cluttered output
+  if (err.name === 'AxiosError') Object.defineProperties (err, {
+    config: { enumerable:false },
+    request: { enumerable:false },
+    response: { enumerable:false },
+  })
+
   // Add original error thrown by the service, if exists
-  const o = err.response?.data?.error ; if (!o) throw err
-  err.message = !o.code || o.code == 'null' ? o.message : `${o.code} - ${o.message}`
-  // err.cause = o instanceof Error ? o : Object.assign (new Error, o)
-  // Object.defineProperty (o, 'stack', { enumerable:false }) //> allow strict equal checks against {code,message}
+  const o = err.response?.data?.error || err
+  const status = o.status || o.code || err.status
+  err.message = status == 'null' ? o.message : `${status} - ${o.message}`
+
+  // Reduce stack trace
+  Error.captureStackTrace (err, _error)
   throw err
 }
 

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -1,0 +1,96 @@
+const {Readable} = require('stream')
+
+class Naxios {
+
+  constructor (defaults) { this.defaults = { ...axios.defaults, ...defaults } }
+  create (defaults) { return new Naxios (defaults) }
+
+  options (url, config)     { return this.request ({ method:'OPTIONS', url, ...config }) }
+  head (url, config)        { return this.request ({ method:'HEAD', url, ...config }) }
+  get (url, config)         { return this.request ({ method:'GET', url, ...config }) }
+  put (url, data, config)   { return this.request ({ method:'PUT', url, ...config, data }) }
+  post (url, data, config)  { return this.request ({ method:'POST', url, ...config, data }) }
+  patch (url, data, config) { return this.request ({ method:'PATCH', url, ...config, data }) }
+  delete (url, config)      { return this.request ({ method:'DELETE', url, ...config }) }
+
+  async request (config) {
+
+    const o = this.options4 (config)
+    const response = await fetch (o.url,o)
+
+    // Axios eagerly reads the response body
+    response.data = await this.data4 (response,o)
+
+    // Axios headers can be accessed as object properties
+    for (let [k,v] of response.headers.entries())
+      response.headers[k.toLowerCase()] = v
+
+    // Axios throws errors for 4xx and 5xx responses
+    let ok = o.validateStatus ??= status => status >= 200 && status < 300 // default
+    if (!ok(response.status)) throw Object.assign (new Error, { response }, response.data.error || {
+      code: response.status,
+      message: response.statusText,
+    })
+
+    return response
+  }
+
+  /**
+   * Turn axios configs into fetch() options
+   */
+  options4 ({ url, params, data, headers, ...rest }) {
+    const o = { ...this.defaults, ...rest, headers: new Headers (this.defaults.headers) }
+    if (headers) for (let [k,v] of Object.entries(headers)) o.headers.set(k,v)
+    if (o.auth) o.headers.set('Authorization', 'Basic ' + btoa (o.auth.username + ':' + o.auth.password||''))
+    if (data) o.body =
+      typeof data === 'string' ? data :
+      data instanceof Readable ? data :
+      JSON.stringify(data)
+    if (params) url += '?' + new URLSearchParams (params)
+    o.url = (o.baseURL||'') + (url[0]==='/'?'':'/') + url
+    return o
+  }
+
+
+  /**
+   * Turn fetch() response into axios response
+   */
+  data4 (res,o) {
+    if (o.transformResponse) return res.text().then(o.transformResponse)
+    else switch (o.responseType) {
+      case 'stream':      return res.body
+      case 'json':        return res.json()
+      case 'text':        return res.text()
+      case 'document':    return res.text()
+      case 'arraybuffer': return res.arrayBuffer()
+    }
+    let ct = res.headers.get('content-type')
+    if (/stream|image|pdf|tar/.test(ct)) return res.body
+    if (/xml/.test(ct)) return res.text()
+    else return res.text().then(x => {
+      try { return JSON.parse(x) }
+      catch { return x }
+    })
+  }
+}
+
+const axios = Object.setPrototypeOf (function (url, config) {
+  if (new.target) return new Naxios (url)
+    else config = typeof url === 'object' ? url : { url, ...config }
+  return axios.request (config)
+}, Naxios.prototype)
+
+axios.defaults = {
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  },
+  duplex: 'half',
+}
+
+axios.interceptors = {
+  request: { use(){}, eject(){} },
+  response: { use(){}, eject(){} },
+}
+
+module.exports = axios

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -13,6 +13,9 @@ class Naxios {
   patch (url, data, config) { return this.request ({ method:'PATCH', url, ...config, data }) }
   delete (url, config)      { return this.request ({ method:'DELETE', url, ...config }) }
 
+  /**
+   * Mimics the axios.request() method, translating it to fetch() API
+   */
   async request (config) {
 
     const o = this.options4 (config)
@@ -34,6 +37,7 @@ class Naxios {
 
     return response
   }
+
 
   /**
    * Turn axios configs into fetch() options
@@ -74,13 +78,24 @@ class Naxios {
   }
 }
 
-const axios = Object.setPrototypeOf (function (url, config) {
+/**
+ * The standard default axios instance
+ * @type {Naxios}
+ */
+const axios = exports = module.exports = Object.setPrototypeOf (function (url, config) {
   if (new.target) return new Naxios (url)
     else config = typeof url === 'object' ? url : { url, ...config }
   return axios.request (config)
 }, Naxios.prototype)
 
-axios.defaults = {
+
+/**
+ * Also supports tests using the like of:
+ * @example
+ *   const { ..., axios } = cds.test //...
+ *   axios.defaults.auth = { username:'alice' }
+ */
+exports.defaults = {
   headers: {
     'Content-Type': 'application/json',
     'Accept': 'application/json',
@@ -88,9 +103,11 @@ axios.defaults = {
   duplex: 'half',
 }
 
-axios.interceptors = {
+
+/**
+ * Not supporting interceptors yet, but ensures code that uses them doesn't break
+ */
+exports.interceptors = {
   request: { use(){}, eject(){} },
   response: { use(){}, eject(){} },
 }
-
-module.exports = axios


### PR DESCRIPTION
This is an opt in for early birds (aka canaries) to try out `cds.test` using standard [`fetch()` API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) instead of _Axios_. 

Tested with our internal test pipelines and seems to work. 
Yet, not enabled by default. 

Proposed way forward: we should merge this PR for further tests by canaries, to remove `axios` dependency in future. 
Optional: The `naxios` module could also be made available and used outside of `cds.test` to migrate other usages of `axios`. 