### PR TITLE
Reapply "Replace chai and axios (#71)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,5 +43,10 @@ jobs:
 
     - name: Axios
       run: |
-        npm add axios --no-save -D
-        npm run test
+        npm i axios --no-save -D
+        npm run node-test
+
+    - name: Chai
+      run: |
+        npm i chai chai-as-promised --no-save -D
+        npm run node-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node-version: [22]  # see https://nodejs.org/en/about/releases/
+        node-version: [24, 22]  # see https://nodejs.org/en/about/releases/
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       if: runner.os != 'Windows'
       run: npm run chest
 
-    - name: Naxios
-      run: npm run jest
-      env:
-        NAXIOS: true
+    - name: Axios
+      run: |
+        npm add axios --no-save -D
+        npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'  # only if package-lock is present

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
     - name: Jest
       run: npm run jest
 
+    - name: Vitest
+      run: npm run vitest -- --watch false
+
     - name: Mocha
       run: npm run mocha
 
@@ -41,12 +44,8 @@ jobs:
       if: runner.os != 'Windows'
       run: npm run chest
 
-    - name: Axios
+    - name: Axios installed
       run: |
-        npm i axios --no-save -D
+        npm i axios -D
         npm run node-test
-
-    - name: Chai
-      run: |
-        npm i chai chai-as-promised --no-save -D
-        npm run node-test
+        git checkout package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.0] - 2026-...
+
+### Fixed
+
+- `cds.test` can now be used in combination with ESM modules without issues.
+- `cds.test` can now be used in combination with chai 6.
+
+### Changed
+
+- Usage of `axios` has been removed in favor of the Fetch API, which is available in Node.js 18 and later. This change allows for a more modern and native approach to making HTTP requests, eliminating the need for an external dependency.
+
+- The `chai` library has been removed as a dependency. This change was made to reduce the number of dependencies and to allow users to choose their preferred assertion library when using `cds.test`. Users can now use any assertion library they prefer without being tied to `chai`.
+
+- When using `expect` from `cds.test`, this now returns the a built-in `expect` implementation which covers the most common matchers with the common _chai_ API.  For compatibility, if `chai` is installed explicitly, the `expect` from `cds.test` will still return the `chai.expect` implementation.
+
+### Removed
+
+- Dependencies to `axios` -> install it yourself if you want to use `axios`.
+- Dependencies to `chai` -> install it yourself if you want to use `chai`.
+
+
 ## [0.4.1] - 2025-11-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 
-- Usage of `axios` has been removed in favor of the Fetch API, which is available in Node.js 18 and later. This change allows for a more modern and native approach to making HTTP requests, eliminating the need for an external dependency.
+- Usage of `axios` has been removed in favor of the Fetch API, which is available in Node.js 18 and later. This change allows for a more modern and native approach to making HTTP requests, eliminating the need for an external dependency.  For compatibility, if it's is installed explicitly, the `axios` library will used.
 
 - The `chai` library has been removed as a dependency. This change was made to reduce the number of dependencies and to allow users to choose their preferred assertion library when using `cds.test`. Users can now use any assertion library they prefer without being tied to `chai`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,27 +8,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [1.0.0] - 2026-...
 
-### Fixed
-
-- `cds.test` can now be used in combination with ESM modules without issues.
-- `cds.test` can now be used in combination with chai 6.
-
 ### Changed
 
 - Usage of `axios` has been removed in favor of the Fetch API, which is available in Node.js 18 and later. This change allows for a more modern and native approach to making HTTP requests, eliminating the need for an external dependency.  For compatibility, if it's is installed explicitly, the `axios` library will used.
 
-- The `chai` library has been removed as a dependency. This change was made to reduce the number of dependencies and to allow users to choose their preferred assertion library when using `cds.test`. Users can now use any assertion library they prefer without being tied to `chai`.
+- When running in Jest, the `expect` from `cds.test` now returns a built-in implementation which covers the most common matchers with the common _chai_ API.  In other runners, the `expect` from `cds.test` returns the `chai.expect` implementation as before.
 
-- When using `expect` from `cds.test`, this now returns the a built-in `expect` implementation which covers the most common matchers with the common _chai_ API.  For compatibility, if `chai` is installed explicitly, the `expect` from `cds.test` will still return the `chai.expect` implementation.
+- Assertion stack traces no longer contain frames of cds-test's own implementation.
 
 ### Removed
 
 - Dependencies to `axios` -> install it yourself if you want to use `axios`.
-- Dependencies to `chai` -> install it yourself if you want to use `chai`.
 
 ### Added
 
-- Assertion stack traces no longer contain frames of cds-test's own implementation.
+- Support for the [Vitest](https://vitest.dev/) test runner.
+
+### Fixed
+
+- `cds.test` can now be used in combination with ESM modules without issues.
+- `cds.test` can now be used in combination with `chai` 6 and `chai-as-promised` 8.
 
 ## [0.4.1] - 2025-11-10
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ npm add -D @cap-js/cds-test
 Add a simple test file `test/bookshop.test.js ` with this content:
 ```js
 const cds = require('@sap/cds')
+const { GET, expect } = cds.test (__dirname+'/..')
 
 describe('Sample tests', () => {
-  const { GET, expect } = cds.test (__dirname+'/..')
 
   it('serves Books', async () => {
     const { data } = await GET `/odata/v4/catalog/Books`
@@ -30,12 +30,17 @@ describe('Sample tests', () => {
 })
 ```
 
-Run it with Jest, for example:
+Run it with Vitest, for example:
+```sh
+npx vitest
+```
+
+Or with Jest:
 ```sh
 npx jest
 ```
 
-`node --test` and `mocha` runners are supported, too, though with less coverage in real-life projects.
+`node --test`, and `mocha` runners are supported, too, though with less coverage in real-life projects.
 
 ## Documentation
 
@@ -55,4 +60,4 @@ We as members, contributors, and leaders pledge to make participation in our com
 
 ## Licensing
 
-Copyright 2024-2025 SAP SE or an SAP affiliate company and cds-test contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/cap-js/cds-test).
+Copyright 2024-2026 SAP SE or an SAP affiliate company and cds-test contributors. Please see our [LICENSE](LICENSE) for copyright and license information. Detailed information including third-party components and their licensing/copyright information is available [via the REUSE tool](https://api.reuse.software/info/github.com/cap-js/cds-test).

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -82,7 +82,7 @@ async function fetch (argv,o) {
   const ignore = /^(\..*|node_modules|_out)$/
   const files = []
   const _read = fs.promises.readdir
-  const _isdir = x => fs.statSync(x).isDirectory()
+  const _isdir = x => fs.lstatSync(x).isDirectory()
   await async function _visit (dir) {
     const entries = await _read (dir)
     return Promise.all (entries.map (each => {

--- a/bin/reporter.js
+++ b/bin/reporter.js
@@ -21,7 +21,7 @@ module.exports = function report_on (test,o) {
 
   // add handlers according to options
   if (o.debug ??= process.env.debug) return debug(o.debug) // eslint-disable-line no-cond-assign
-  if (o.verbose ??= files.length === 1 && !o.silent) verbose(); else silent()
+  if (o.verbose ??= files.length === 1 && !o.silent) verbose(); else silent() // eslint-disable-line no-cond-assign
   if (o.unmute) unmute()
   common()
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,2 @@
+import cds from '@sap/cds/eslint.config.mjs'
+export default [ ...cds.recommended ]

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,3 +1,0 @@
-export default {
-  silent: true
-}

--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -1,7 +1,7 @@
 /**
  * Instances of this class are constructed and returned by cds.test().
  */
-class Test extends require('./axios') {
+class Test extends require('./xaxios') {
 
   /**
    * Allows: const { GET, expect, test } = cds.test()
@@ -145,27 +145,7 @@ class Test extends require('./axios') {
    * Lazily loads and returns an instance of chai
    * @type {import('chai')}
    */
-  get chai() {
-    if (global.chai)  return global.chai
-    const chai = require('chai')
-    chai.use (require('chai-subset'))
-    const chaip = require('chai-as-promised')
-    chai.use (chaip.default/*v8 on ESM*/ ?? chaip/*v7*/)
-    return chai
-    function require (mod) { try { return module.require(mod) } catch(e) {
-      if (e.code === 'MODULE_NOT_FOUND')
-        throw new Error (`Failed to load required package '${mod}'. Please add it thru:`
-        + `\n  npm add -D chai chai-as-promised chai-subset`, {cause: e})
-      else if (e.name === 'SyntaxError') // Jest stumbling over ESM
-        throw new Error (`Jest failed to load ESM package '${mod}'.`
-        + `\nDowngrade '${mod}' to the major version before, or use a different test runner like 'node --test'.\n`, {cause: e})
-      else if (e.code === 'ERR_REQUIRE_ESM') // node --test on older Node versions
-        throw new Error (`Failed to load ESM package '${mod}'. This only is supported on Node.js >= 23.`
-          + `\nUpgrade your Node.js installation or downgrade '${mod}' to the major version before.\n`, {cause: e})
-      else throw e
-    }}
-  }
-  // set expect(x) { super.expect = x }
+  get chai() { return super.chai = require('./chai') }
   get expect() { return this.chai.expect }
   get assert() { return this.chai.assert }
   get should() { return this.chai.should() }

--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -140,15 +140,16 @@ class Test extends require('./xaxios') {
   }
   /** @deprecated */ verbose(){ return this }
 
-
-  /**
-   * Lazily loads and returns an instance of chai
-   * @type {import('chai')}
-   */
-  get chai() { return super.chai = require('./chai') }
+  /** 
+   * Returns chai's `expect` function, if chai is available, otherwise a compatible 
+   * built-in `expect` function, covering a subset of most used chai assertions.
+   * @returns {import('./expect')} 
+   */ 
   get expect() { return this.chai.expect }
-  get assert() { return this.chai.assert }
-  get should() { return this.chai.should() }
+
+  /** @deprecated */ get chai() { return super.chai = require('./chai') }
+  /** @deprecated */ get assert() { return this.chai.assert }
+  /** @deprecated */ get should() { return this.chai.should() }
 }
 
 

--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -1,3 +1,7 @@
+const cds = require ('@sap/cds/lib')
+const { path, isdir, local } = cds.utils
+
+
 /**
  * Instances of this class are constructed and returned by cds.test().
  */
@@ -6,11 +10,11 @@ class Test extends require('./xaxios') {
   /**
    * Allows: const { GET, expect, test } = cds.test()
    */
-  test = this
-
-  get cds() { return require('@sap/cds/lib') }
+  get test() { return this }
   get sleep() { return super.sleep = require('node:timers/promises').setTimeout }
   get data() { return super.data = require('./data') }
+  get cds() { return cds }
+
 
   /**
    * Launches a cds server with arbitrary port and returns a subclass which
@@ -23,11 +27,10 @@ class Test extends require('./xaxios') {
       case 'run': if (args.length > 0) args.unshift ('--project'); break
       default: this.in(folder_or_cmd); args.push ('--in-memory?')
     }
-    const {cds} = this
 
     // launch cds server...
     before (async ()=>{
-      process.env.cds_test_temp = cds.utils.path.resolve (cds.root,'_out',''+process.pid)
+      process.env.cds_test_temp = path.resolve (cds.root,'_out',''+process.pid)
       if (!args.includes('--port')) args.push ('--port', '0')
       let { server, url } = await cds.exec (...args)
       this.server = server
@@ -43,6 +46,7 @@ class Test extends require('./xaxios') {
     return this
   }
 
+
   /**
    * Serving projects from subfolders under the root specified by a sequence
    * of path components which are concatenated with path.resolve().
@@ -50,10 +54,8 @@ class Test extends require('./xaxios') {
    */
   in (folder, ...paths) {
     if (!folder) return this
-    const {cds} = this, { isdir, local } = cds.utils
     // try to resolve folder relative to cds.root, or as a node module
     try {
-      const path = require('path')
       folder = isdir (path.resolve (cds.root, folder, ...paths))
       || path.join (require.resolve (folder+'/package.json').slice(0,-13), ...paths)
     } catch {
@@ -77,6 +79,7 @@ class Test extends require('./xaxios') {
     return this
   }
 
+
   /**
    * Method to spy on a function in an object, similar to jest.spyOn().
    */
@@ -91,16 +94,15 @@ class Test extends require('./xaxios') {
     return o[f] = fn
   }
 
+
   /**
    * For usage in repl, e.g. var test = await cds.test()
    */
   then (resolve) {
-    if (this.server) {
-      resolve({ server: this.server, url: this.url })
-    } else {
-      this.cds.once('listening', resolve)
-    }
+    if (this.server) resolve ({ server: this.server, url: this.url })
+    else cds.once ('listening', resolve)
   }
+
 
   /**
    * Captures console.log output.
@@ -108,8 +110,8 @@ class Test extends require('./xaxios') {
   log (_capture) {
     const {console} = global, {format} = require('util')
     const log = { output: '' }
-    beforeAll(()=> global.console = { __proto__: console,
-      log: _capture ??= (..._)=> log.output += format(..._)+'\n',
+    beforeAll (()=> global.console = { __proto__: console,
+      log: _capture ??= (..._) => log.output += format(..._)+'\n',
       info: _capture,
       warn: _capture,
       debug: _capture,
@@ -121,6 +123,7 @@ class Test extends require('./xaxios') {
     afterEach (log.clear = ()=>{ log.output = '' })
     return log
   }
+
 
   /**
    * Silences all console log output, e.g.: CDS_TEST_SILENT=y jest/mocha ...
@@ -138,18 +141,17 @@ class Test extends require('./xaxios') {
     }
     return this
   }
-  /** @deprecated */ verbose(){ return this }
+
 
   /** 
-   * Returns chai's `expect` function, if chai is available, otherwise a compatible 
-   * built-in `expect` function, covering a subset of most used chai assertions.
+   * Returns `chai.expect` function, or a lookalike.
    * @returns {import('./expect')} 
    */ 
   get expect() { return this.chai.expect }
 
-  /** @deprecated */ get chai() { return super.chai = require('./chai') }
   /** @deprecated */ get assert() { return this.chai.assert }
   /** @deprecated */ get should() { return this.chai.should() }
+  /** @deprecated */ get chai() { return super.chai = require('./chai') }
 }
 
 
@@ -160,15 +162,33 @@ module.exports = exports = Object.assign ((..._) => (new Test).run(..._), { Test
 Object.setPrototypeOf (exports, Test.prototype)
 
 
-// Provide same global functions for jest and mocha
-;(function _support_jest_and_mocha() {
-  const runner = exports.runner = (
-    global.cds?.repl || process.env.CDS_TEST_FAKE ? 'repl' :
-    'beforeAll' in global ? 'jest' :
-    'before' in global ? 'mocha' :
-    'node-test'
+/**
+ * Provide same global functions for node --test, jest, mocha, and vitest, 
+ * to allow running tests with any of these runners without changing test code. 
+ * Note that cds.test() must be called before importing test code to ensure the 
+ * correct runner is detected and supported.
+ */
+exports.runner ??= function _support_jest_and_mocha() {
+  
+  // Determine the test runner we are running in...
+  const runner = (
+    global.cds?.repl              ? 'repl' :
+    process.env.CDS_TEST_FAKE     ? 'repl' :
+    '__vitest_index__' in global  ? 'vitest' :
+    'beforeAll' in global         ? 'jest' :
+    'before' in global            ? 'mocha' :
+    /* else */                      'node-test'
   )
-  global._cds_test_fixture ??= require ('./fixtures/'+runner+'.js')
-  if (runner === 'node-test') describe?.('<next>', ()=>{}) //> to signal the start of a test file
-  else if (runner === 'mocha' && process.env.CDS_TEST_SILENT !== 'false') exports.silent()
-})()
+
+  // Load support for the detected runner, which will define global test 
+  // functions like describe(), it(), expect(), ...
+  require ('./fixtures/'+runner+'.js')
+
+  // Silence test output by default if not explicitly disabled, 
+  // to avoid cluttering CI logs, but allow it for mocha which 
+  const { CDS_TEST_SILENT } = process.env; if (/true|y|1/.test(CDS_TEST_SILENT)) exports.silent()
+  else if (CDS_TEST_SILENT !== 'false' && runner === 'node-test') exports.silent()
+  else if (CDS_TEST_SILENT !== 'false' && runner === 'mocha') exports.silent()
+  
+  return runner
+}()

--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -10,7 +10,7 @@ class Test extends require('./xaxios') {
 
   get cds() { return require('@sap/cds/lib') }
   get sleep() { return super.sleep = require('node:timers/promises').setTimeout }
-  get data() { return super.data = new (require('./data'))}
+  get data() { return super.data = require('./data') }
 
   /**
    * Launches a cds server with arbitrary port and returns a subclass which

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -13,9 +13,22 @@ module.exports = CHAI && chai() || new class chai {
   }
 }
 
-function chai() { try {
-  const chai = require ('chai')
-  try { const chai_ap = require('chai-as-promised'); chai.use (chai_ap.default ?? chai_ap) } catch (e) {DEBUG?.error(e)}
-  try { chai.use (require('chai-subset')) } catch (e) {DEBUG?.error(e)} // subset now part of chai, but support it here for older chai versions
+function chai() {
+  try {
+    var chai = require ('chai')
+  } catch (e) {
+    // Includes Jest's ESM loading errors for chai >=7. Even if --experimental-modules flag is used, Jest doesn't support the require() style.
+    // Return and fall back to built-in chai here.
+    return DEBUG?.error(e)
+  }
+
+  try {
+    const chai_ap = require('chai-as-promised')
+    chai.use (chai_ap.default ?? chai_ap) // for ESM and non-ESM versions
+  } catch (e) { if (e.code === 'MODULE_NOT_FOUND') DEBUG?.error(e); else throw e }
+  try {
+    chai.use (require('chai-subset')) // subset now part of chai, but support it here for older chai versions
+  } catch (e) { if (e.code === 'MODULE_NOT_FOUND') DEBUG?.error(e); else throw e }
+
   return chai
-} catch (e) {DEBUG?.error(e)}}
+}

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -11,7 +11,7 @@ module.exports = global.__vitest_index__?.chai //> used in Vitest
     })
   }
 
-  constructor() { beforeAll (async () => { 
+  constructor() { global.beforeAll (async () => { 
     try {
       // Loading chai and chai-as-promised dynamically...
       $chai = await import ('chai') 

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -14,14 +14,17 @@ module.exports = CHAI && chai() || new class chai {
 }
 
 function chai() {
-  try {
-    var chai = require ('chai')
-  } catch (e) {
-    // Includes Jest's ESM loading errors for chai >=7. Even if --experimental-modules flag is used, Jest doesn't support the require() style.
-    // Return and fall back to built-in chai here.
-    return DEBUG?.error(e)
-  }
 
+  // Try to load chai and report any loading errors, but don't throw to allow 
+  // falling back to built-in expect function.
+  // Includes Jest's ESM loading errors for chai >=7. 
+  // Even if --experimental-modules flag is used, Jest doesn't support the require() style.
+  try { 
+    var chai = require ('chai') 
+  } catch (e) { return DEBUG?.error(e) }
+
+  // Try to load chai plugins individually and report any loading errors, 
+  // Rethrow any errors other than "MODULE_NOT_FOUND" to report them in test output.
   try {
     const chai_ap = require('chai-as-promised')
     chai.use (chai_ap.default ?? chai_ap) // for ESM and non-ESM versions

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,5 +1,6 @@
-const { NCHAI } = process.env
-module.exports = (!NCHAI && chai()) || new class chai {
+const CHAI = !/\b(false)\b/.test(process.env.CHAI) // to disable chai mode even if chai is installed
+
+module.exports = (CHAI && chai()) || new class chai {
   get assert() { return super.assert = require('node:assert')}
   get expect() { return super.expect = require('./expect')}
   should() {
@@ -12,7 +13,7 @@ module.exports = (!NCHAI && chai()) || new class chai {
 
 function chai() { try {
   const chai = require ('chai')
-  try { chai.use (require('chai-as-promised')) } catch {/* ignore */}
+  try { chai.use (require('chai-as-promised')) } catch (err) {console.error(err)}
   try { chai.use (require('chai-subset')) } catch {/* ignore */} // subset now part of chai, but support it hete for older chai versions
   return chai
-} catch {/* ignore */}}
+} catch (err) {console.error(err)}}

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,37 +1,30 @@
-const CHAI = !/\b(false)\b/.test(process.env.CHAI) // to disable chai mode even if chai is installed
-const DEBUG = /\b(test)\b/.test(process.env.DEBUG) ? console : null
 
-/** @type {import('chai')} */
-module.exports = CHAI && chai() || new class chai {
-  get assert() { return super.assert = require('node:assert')}
-  get expect() { return super.expect = require('./expect')}
-  should() {
-    const expect = this.expect
+module.exports = global.__vitest_index__?.chai //> used in Vitest 
+|| new class chai { //> used in Node --test, Chest, Jest, Mocha
+
+  // Static chai interface used in cds.test
+  assert (...args) { return $chai.assert (...args) }
+  expect (...args) { return $chai.expect (...args) }
+  should () {
     Object.defineProperty (Object.prototype, 'should', {
-      get() { return expect(this) }
+      get() { return $chai.expect (this) }
     })
   }
+
+  constructor() { beforeAll (async () => { 
+    try {
+      // Loading chai and chai-as-promised dynamically...
+      $chai = await import ('chai') 
+      .then (chai => import ('chai-as-promised') 
+      .then (chap => chai.use (chap.default||chap)))
+    } catch { 
+      // Fallback for Jest without --experimental-vm-modules
+      $chai.assert = require ('node:assert')
+      $chai.expect = require ('./expect')
+    }
+    Object.assign (this.assert, $chai.assert)
+    Object.assign (this.expect, $chai.expect)
+  })}
 }
 
-function chai() {
-
-  // Try to load chai and report any loading errors, but don't throw to allow 
-  // falling back to built-in expect function.
-  // Includes Jest's ESM loading errors for chai >=7. 
-  // Even if --experimental-modules flag is used, Jest doesn't support the require() style.
-  try { 
-    var chai = require ('chai') 
-  } catch (e) { return DEBUG?.error(e) }
-
-  // Try to load chai plugins individually and report any loading errors, 
-  // Rethrow any errors other than "MODULE_NOT_FOUND" to report them in test output.
-  try {
-    const chai_ap = require('chai-as-promised')
-    chai.use (chai_ap.default ?? chai_ap) // for ESM and non-ESM versions
-  } catch (e) { if (e.code === 'MODULE_NOT_FOUND') DEBUG?.error(e); else throw e }
-  try {
-    chai.use (require('chai-subset')) // subset now part of chai, but support it here for older chai versions
-  } catch (e) { if (e.code === 'MODULE_NOT_FOUND') DEBUG?.error(e); else throw e }
-
-  return chai
-}
+let $chai = {} //> loaded dynamically in constructor above 

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,0 +1,17 @@
+module.exports = chai() || new class chai {
+  get assert() { return super.assert = require('node:assert')}
+  get expect() { return super.expect = require('./expect')}
+  should() {
+    const expect = this.expect
+    Object.defineProperty (Object.prototype, 'should', {
+      get() { return expect(this) }
+    })
+  }
+}
+
+function chai() { try {
+  const chai = require ('chai')
+  try { chai.use (require('chai-as-promised')) } catch {/* ignore */}
+  try { chai.use (require('chai-subset')) } catch {/* ignore */} // subset now part of chai, but support it hete for older chai versions
+  return chai
+} catch {/* ignore */}}

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,4 +1,5 @@
-module.exports = chai() || new class chai {
+const { NCHAI } = process.env
+module.exports = (!NCHAI && chai()) || new class chai {
   get assert() { return super.assert = require('node:assert')}
   get expect() { return super.expect = require('./expect')}
   should() {

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,4 +1,5 @@
 const CHAI = !/\b(false)\b/.test(process.env.CHAI) // to disable chai mode even if chai is installed
+const DEBUG = /\b(test)\b/.test(process.env.DEBUG) ? console : null
 
 module.exports = (CHAI && chai()) || new class chai {
   get assert() { return super.assert = require('node:assert')}
@@ -13,7 +14,7 @@ module.exports = (CHAI && chai()) || new class chai {
 
 function chai() { try {
   const chai = require ('chai')
-  try { const chai_ap = require('chai-as-promised'); chai.use (chai_ap.default ?? chai_ap) } catch {/* ignore */}
-  try { chai.use (require('chai-subset')) } catch {/* ignore */} // subset now part of chai, but support it here for older chai versions
+  try { const chai_ap = require('chai-as-promised'); chai.use (chai_ap.default ?? chai_ap) } catch (e) {DEBUG?.error(e)}
+  try { chai.use (require('chai-subset')) } catch (e) {DEBUG?.error(e)} // subset now part of chai, but support it here for older chai versions
   return chai
-} catch {/* ignore */}}
+} catch (e) {DEBUG?.error(e)}}

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -13,7 +13,7 @@ module.exports = (CHAI && chai()) || new class chai {
 
 function chai() { try {
   const chai = require ('chai')
-  try { chai.use (require('chai-as-promised')) } catch (err) {console.error(err)}
-  try { chai.use (require('chai-subset')) } catch {/* ignore */} // subset now part of chai, but support it hete for older chai versions
+  try { const chai_ap = require('chai-as-promised'); chai.use (chai_ap.default ?? chai_ap) } catch {/* ignore */}
+  try { chai.use (require('chai-subset')) } catch {/* ignore */} // subset now part of chai, but support it here for older chai versions
   return chai
-} catch (err) {console.error(err)}}
+} catch {/* ignore */}}

--- a/lib/chai.js
+++ b/lib/chai.js
@@ -1,7 +1,8 @@
 const CHAI = !/\b(false)\b/.test(process.env.CHAI) // to disable chai mode even if chai is installed
 const DEBUG = /\b(test)\b/.test(process.env.DEBUG) ? console : null
 
-module.exports = (CHAI && chai()) || new class chai {
+/** @type {import('chai')} */
+module.exports = CHAI && chai() || new class chai {
   get assert() { return super.assert = require('node:assert')}
   get expect() { return super.expect = require('./expect')}
   should() {

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,52 +1,37 @@
 const cds = require('@sap/cds')
 
-class DataUtil {
+/** @deprecated */
+exports.autoReset = () => global.beforeEach (exports.reset)
 
-  constructor() {
-    // This is to support simplified usage like that: beforeEach(test.data.reset)
-    const {reset} = this; this.reset = (x) => {
-      if (typeof x === 'function') reset.call(this).then(x,x) // x is the done callback of jest -> no return
-      else if (x?.assert) return reset.call(this) // x is a node --test TestContext object -> ignore
-      else return reset.call(this,x) // x is a db service instance
-    }
-  }
-
-  autoReset() {
-    global.beforeEach (() => this.reset())
-  }
-
-  async deploy(db) {
-    if (!db)  db = await cds.connect.to('db')
-    await cds.deploy.data(db)
-  }
-
-  async delete(db) {
-    if (!db)  db = await cds.connect.to('db')
-    if (!this._deletes) {
-      this._deletes = []
-      for (const entity of db.model.each('entity')) {
-        if (!entity.query && entity['@cds.persistence.skip'] !== true) {
-          this._deletes.push(DELETE.from(entity))
-        }
-        if (entity.drafts) {
-          this._deletes.push(DELETE.from(entity.drafts))
-        }
-      }
-    }
-    if (this._deletes.length > 0) {
-      await db.run(this._deletes)
-    }
-  }
-
-  /* delete + new deploy from csv */
-  async reset(db) {
-    if (!db) db = await cds.connect.to('db')
-    await this.delete(db)
-    await this.deploy(db)
-  }
-
+exports.deploy = async function (db) {
+  if (!db) db = await cds.connect.to('db')
+  await cds.deploy.data(db)
 }
 
-module.exports = DataUtil
+exports.delete = async function (db) {
+  if (!db) db = await cds.connect.to('db')
+  const deletes = _deletes4 (db.model)
+  if (deletes.length) await db.run(deletes)
+}
 
-/* eslint no-console: off */
+exports.reset = async function() {
+  let [db] = arguments // to avoid confusion with done callback in beforeEach
+  if (!db?.isDatabaseService) db = await cds.connect.to('db')
+  await exports.delete(db)
+  await exports.deploy(db)
+}
+
+const DELETES = Symbol.for('cds.test.deletes')
+const _deletes4 = model => {
+  if (DELETES in model) return model[DELETES]
+  const deletes = []
+  for (const entity of model.each('entity')) {
+    if (!entity.query && entity['@cds.persistence.skip'] !== true) {
+      deletes.push(DELETE.from(entity))
+    }
+    if (entity.drafts) {
+      deletes.push(DELETE.from(entity.drafts))
+    }
+  }
+  return model[DELETES] = deletes
+}

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -91,9 +91,9 @@ class Core {
 
   subset (x, _fail = () => this.should`contain subset ${x}`) {
     return this.assert(a => {
-      if (is.array(a) && is.array(x)) return x.every(x => a.some(o => compare(o,x)))
-      if (is.array(a) && !is.array(x)) return a.some(o => compare(o,x))
-      else return compare(a,x)
+      if (is.array(a) && is.array(x)) return x.every(x => a.some(o => compareSubset(o,x)))
+      if (is.array(a) && !is.array(x)) return a.some(o => compareSubset(o,x))
+      else return compareSubset(a,x)
     }, _fail)
   }
 
@@ -382,4 +382,24 @@ function compare (a, b, strict) {
     }
     return true
   }(a, b)
+}
+
+function compareSubset (a, b, strict) {
+  if (a === b) return true
+  if (typeof b === 'function') return b(a)
+  if (Buffer.isBuffer(a)) return Buffer.isBuffer(b) && a.equals(b)
+  if (is.array(a) && is.array(b)) {
+    if (strict && a.length !== b.length) return false
+    return b.every(x => a.some(v => compareSubset(v, x, strict)))
+  }
+  if (is.object(a) && is.object(b)) {
+    if (strict) for (let k of Object.keys(a)) if (!(k in b)) return false
+    for (let k in b) {
+      const v = a[k], x = b[k]; if (v === x) continue
+      if (typeof x === 'function') { if (x(v)) continue; else return false }
+      if (!compareSubset(v, x, strict)) return false
+    }
+    return true
+  }
+  return false
 }

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -7,6 +7,7 @@ const format = x => inspect(
   { colors: true, sorted: true, depth: 11 }
 )
 
+/** @returns {Assertion} */
 const expect = module.exports = actual => {
   const chainable = function (x) { return this.call(x) }; delete chainable.length
   return Object.setPrototypeOf(chainable, new Assertion(actual))
@@ -314,17 +315,7 @@ class Jest extends Chai {
       () => this.should`have been last called with ${args}`
     )
   }
-
-  static expect() {
-    expect.stringMatching = x => a => (is.regexp(x) ? x : RegExp(x)).test?.(a)
-    expect.stringContaining = x => a => a?.includes(x)
-    expect.arrayContaining = x => a => x.every(e => a.includes(e))
-    expect.objectContaining = x => a => compare(a,x)
-    expect.extend = ()=> unsupported('extend')
-    expect.any = is.any
-  }
 }
-Jest.expect()
 
 
 class Assertion extends Jest {
@@ -345,6 +336,13 @@ class AssertionError extends Error {
 // AssertionError.prototype = Object.create (Error.prototype, {constructor:{value: AssertionError }})
 // AssertionError.__proto__ = Error
 
+
+expect.stringMatching = x => a => (is.regexp(x) ? x : RegExp(x)).test?.(a)
+expect.stringContaining = x => a => a?.includes(x)
+expect.arrayContaining = x => a => x.every(e => a.includes(e))
+expect.objectContaining = x => a => compare(a,x)
+expect.extend = ()=> unsupported('extend')
+expect.any = is.any
 
 expect.fail = function (actual, expected, message) {
   if (arguments.length === 1) throw new AssertionError (actual, expect.fail)

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -368,6 +368,7 @@ function compare (a, b, strict) {
   if (a == b) return true
   if (Buffer.isBuffer(a)) return Buffer.isBuffer(b) && a.equals(b)
   return function _recurse (a, b) {
+    if (typeof b === 'function') return b(a)
     if (!a || typeof a !== 'object') return false
     if (!b || typeof b !== 'object') return false
     if (strict)

--- a/lib/expect.js
+++ b/lib/expect.js
@@ -320,6 +320,7 @@ class Jest extends Chai {
     expect.stringContaining = x => a => a?.includes(x)
     expect.arrayContaining = x => a => x.every(e => a.includes(e))
     expect.objectContaining = x => a => compare(a,x)
+    expect.extend = ()=> unsupported('extend')
     expect.any = is.any
   }
 }

--- a/lib/fixtures/node-test.js
+++ b/lib/fixtures/node-test.js
@@ -11,8 +11,6 @@ global.test = global.it = test
 global.xtest = test.skip
 global.xdescribe = describe.skip
 
-global.expect = require('../expect')
-
 global.jest = {
   fn: (..._) => mock.fn (..._),
   spyOn: (..._) => mock.method (..._),

--- a/lib/fixtures/node-test.js
+++ b/lib/fixtures/node-test.js
@@ -11,16 +11,7 @@ global.test = global.it = test
 global.xtest = test.skip
 global.xdescribe = describe.skip
 
-global.chai = {
-  expect: global.expect = require('../expect'),
-  should() {
-    const expect = this.expect
-    Object.defineProperty (Object.prototype, 'should', {
-      get() { return expect(this) }
-    })
-  },
-  fake: true
-}
+global.expect = require('../expect')
 
 global.jest = {
   fn: (..._) => mock.fn (..._),

--- a/lib/fixtures/repl.js
+++ b/lib/fixtures/repl.js
@@ -3,4 +3,3 @@ global.beforeAll  = global.before    = (msg,fn) => (fn||msg)()
 global.afterAll   = global.after     = (msg,fn) => repl.on?.('exit',fn||msg)
 global.beforeEach = global.afterEach = ()=>{}
 global.describe   = ()=>{}
-global.expect = require('../expect')

--- a/lib/fixtures/repl.js
+++ b/lib/fixtures/repl.js
@@ -3,6 +3,4 @@ global.beforeAll  = global.before    = (msg,fn) => (fn||msg)()
 global.afterAll   = global.after     = (msg,fn) => repl.on?.('exit',fn||msg)
 global.beforeEach = global.afterEach = ()=>{}
 global.describe   = ()=>{}
-global.chai = {
-  expect: global.expect = require('../expect')
-}
+global.expect = require('../expect')

--- a/lib/fixtures/vitest.js
+++ b/lib/fixtures/vitest.js
@@ -1,0 +1,56 @@
+const vitest = global.__vitest_index__
+
+const { describe, beforeEach, afterEach, beforeAll, afterAll, test, vi, chai } = vitest
+global.describe ??= describe
+global.beforeEach ??= beforeEach
+global.afterEach ??= afterEach
+global.beforeAll ??= beforeAll
+global.afterAll ??= afterAll
+global.test ??= global.it ??= test
+global.xtest ??= test.skip
+global.xdescribe ??= describe.skip
+
+global.before = (a,b) => beforeAll (typeof a === 'function' ? a : b)
+global.after = (a,b) => afterAll (typeof a === 'function' ? a : b)
+global.expect ??= vitest.expect
+
+// global.mock = vi
+global.jest = { __proto__: vi,
+  mock: (module, fn = ()=>{}, options) => vi.mock (
+    module, (...args)=> ({ default: fn(...args) }), 
+    options
+  ),
+}
+
+const cap = require ('chai-as-promised')
+chai.use (cap.default || cap)
+
+// Add chai-as-promised like functionality to vitest's chai, so that we can 
+// write expect(promise).to.be.fulfilled and expect(promise).to.be.rejected
+// chai.use (function (chai, utils) {
+
+//   const Assertion = chai.Assertion
+
+//   utils.addProperty (Assertion.prototype, 'fulfilled', function () {
+//     const fulfilled = 'expected #{this} to be fulfilled but it was rejected with #{act}'
+//     const rejected = 'expected #{this} to be rejected but it was fulfilled with #{act}'
+//     const promised = Promise.resolve(this._obj).then(
+//       () => this.assert (true, fulfilled, rejected),
+//       () => this.assert (false, fulfilled, rejected)
+//     )
+//     this.then = promised.then.bind(promised)
+//     return this
+//   })
+
+//   utils.addProperty (chai.Assertion.prototype, 'rejected', function () {
+//     const rejected = 'expected #{this} to be rejected but it was fulfilled with #{act}'
+//     const fulfilled = 'expected #{this} to be fulfilled but it was rejected with #{act}'
+//     const promised = Promise.resolve(this._obj).then(
+//       () => this.assert (false, fulfilled, rejected),
+//       () => this.assert (true, fulfilled, rejected)
+//     )
+//     this.then = promised.then.bind(promised)
+//     return this
+//   })
+
+// })

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -49,6 +49,7 @@ class Naxios {
     const o = { ...this.defaults, ...rest, headers: new Headers (this.defaults.headers) }
     if (headers) for (let [k,v] of Object.entries(headers)) o.headers.set(k,v)
     if (o.auth) o.headers.set('Authorization', 'Basic ' + btoa (o.auth.username + ':' + o.auth.password||''))
+    if (o.maxRedirects === 0) { o.redirect = 'manual'; delete o.maxRedirects }
     if (data) o.body =
       typeof data === 'string' ? data :
       data instanceof Readable ? data :

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -50,6 +50,7 @@ class Naxios {
     if (headers) for (let [k,v] of Object.entries(headers)) o.headers.set(k,v)
     if (o.auth) o.headers.set('Authorization', 'Basic ' + btoa (o.auth.username + ':' + o.auth.password||''))
     if (o.maxRedirects === 0) { o.redirect = 'manual'; delete o.maxRedirects }
+    if (o.timeout) { o.signal = AbortSignal.timeout(o.timeout); delete o.timeout }// eslint-disable-line no-undef
     if (data) o.body =
       typeof data === 'string' ? data :
       data instanceof Readable ? data :

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -53,6 +53,7 @@ class Naxios {
       typeof data === 'string' ? data :
       data instanceof Readable ? data :
       JSON.stringify(data)
+    if (typeof data === 'object' && !o.headers.has('Content-Type')) o.headers.set('Content-Type', 'application/json')
     if (params) url += '?' + new URLSearchParams (params)
     o.url = (o.baseURL||'') + (url[0]==='/'?'':'/') + url
     return o

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -1,4 +1,4 @@
-const {Readable} = require('stream')
+const { Readable } = require('stream')
 
 class Naxios {
 
@@ -87,8 +87,7 @@ class Naxios {
  */
 const axios = exports = module.exports = Object.setPrototypeOf (function (url, config) {
   if (new.target) return new Naxios (url)
-    else config = typeof url === 'object' ? url : { url, ...config }
-  return axios.request (config)
+  return axios.request (typeof url === 'object' ? url : { url, ...config })
 }, Naxios.prototype)
 
 

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -77,10 +77,6 @@ class Naxios {
     let ct = res.headers.get('content-type')
     if (/stream|image|pdf|tar/.test(ct)) return res.body
     if (/xml/.test(ct)) return res.text()
-    if (/multipart\/mixed/.test(ct)) {
-      const boundary = ct.match(/boundary=(.*)/)[1]
-      return res.text().then(t => multipart2json(t, boundary))
-    }
     else return res.text().then(x => {
       try { return JSON.parse(x) }
       catch { return x }
@@ -120,12 +116,4 @@ exports.defaults = {
 exports.interceptors = {
   request: { use(){}, eject(){} },
   response: { use(){}, eject(){} },
-}
-
-const multipart2json = async (res, boundry) => {
-  res = res.replace(/HTTP\/1.1 (\d+)[^(\r\n)]*/g, 'POST /$1 HTTP/1.1')
-  const multipartToJson = require('@sap/cds/libx/odata/parse/multipartToJson')
-  const { requests: responses } = await multipartToJson(res, boundry)
-  for (const each of responses) each.status = Number(each.url.split('/')[1])
-  return { responses }
 }

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -50,7 +50,8 @@ class Naxios {
     if (headers) for (let [k,v] of Object.entries(headers)) o.headers.set(k,v)
     if (o.auth) o.headers.set('Authorization', 'Basic ' + btoa (o.auth.username + ':' + o.auth.password||''))
     if (o.maxRedirects === 0) { o.redirect = 'manual'; delete o.maxRedirects }
-    if (o.timeout) { o.signal = AbortSignal.timeout(o.timeout); delete o.timeout }// eslint-disable-line no-undef
+    // TODO investigate why timeout support leads to open handles reported by test runners
+    // if (o.timeout) { o.signal = AbortSignal.timeout(o.timeout); delete o.timeout }// eslint-disable-line no-undef
     if (data) o.body =
       typeof data === 'string' ? data :
       data instanceof Readable ? data :

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -54,8 +54,9 @@ class Naxios {
       data instanceof Readable ? data :
       JSON.stringify(data)
     if (typeof data === 'object' && !o.headers.has('Content-Type')) o.headers.set('Content-Type', 'application/json')
+    if (!url.startsWith('http')) url = (o.baseURL||'') + (url[0]==='/'?'':'/') + url
     if (params) url += '?' + new URLSearchParams (params)
-    o.url = (o.baseURL||'') + (url[0]==='/'?'':'/') + url
+    o.url = url
     return o
   }
 

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -77,6 +77,10 @@ class Naxios {
     let ct = res.headers.get('content-type')
     if (/stream|image|pdf|tar/.test(ct)) return res.body
     if (/xml/.test(ct)) return res.text()
+    if (/multipart\/mixed/.test(ct)) {
+      const boundary = ct.match(/boundary=(.*)/)[1]
+      return res.text().then(t => multipart2json(t, boundary))
+    }
     else return res.text().then(x => {
       try { return JSON.parse(x) }
       catch { return x }
@@ -116,4 +120,12 @@ exports.defaults = {
 exports.interceptors = {
   request: { use(){}, eject(){} },
   response: { use(){}, eject(){} },
+}
+
+const multipart2json = async (res, boundry) => {
+  res = res.replace(/HTTP\/1.1 (\d+)[^(\r\n)]*/g, 'POST /$1 HTTP/1.1')
+  const multipartToJson = require('@sap/cds/libx/odata/parse/multipartToJson')
+  const { requests: responses } = await multipartToJson(res, boundry)
+  for (const each of responses) each.status = Number(each.url.split('/')[1])
+  return { responses }
 }

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -71,7 +71,7 @@ class Naxios {
       case 'json':        return res.json()
       case 'text':        return res.text()
       case 'document':    return res.text()
-      case 'arraybuffer': return res.arrayBuffer()
+      case 'arraybuffer': return res.arrayBuffer().then(Buffer.from)
     }
     let ct = res.headers.get('content-type')
     if (/stream|image|pdf|tar/.test(ct)) return res.body

--- a/lib/xaxios.js
+++ b/lib/xaxios.js
@@ -1,11 +1,8 @@
-const { NAXIOS } = process.env //> for early birds, aka canaries
-if (NAXIOS) require = id => module.require (id === 'axios' ? './naxios' : id) // eslint-disable-line no-global-assign
-
 class AxiosProvider {
 
   get axios() {
     const http = require('node:http')
-    const axios = require('axios')
+    const axios = require('./naxios')
     return super.axios = axios.create ({
       httpAgent: new http.Agent({ keepAlive: false}), //> https://github.com/nodejs/node/issues/47130
       headers: { 'content-type': 'application/json' },

--- a/lib/xaxios.js
+++ b/lib/xaxios.js
@@ -1,13 +1,10 @@
 
 class AxiosProvider {
 
-  /**
-   * @deprecated configure on request level instead, e.g. `GET('/path', { headers:{ Authorization: '...' } })`
-   */
+  /** @protected */
   get axios() {
+    const axios = the_real_axios() || require('./naxios')
     const http = require('node:http')
-    const AXIOS = !/\b(false)\b/.test(process.env.AXIOS) // to disable axios mode even if axios is installed
-    const axios = (AXIOS && _axios()) ? require('axios') : require('./naxios')
     return super.axios = axios.create ({
       httpAgent: new http.Agent({ keepAlive: false}), //> https://github.com/nodejs/node/issues/47130
       headers: { 'content-type': 'application/json' },
@@ -82,9 +79,10 @@ const _error = (err) => {
   throw err
 }
 
-const _axios = () => {
-  try {
-    return require('axios')
+const the_real_axios = () => {
+  if (process.env.AXIOS !== 'false') try {
+    const { devDependencies, dependencies } = require (require('path').join(process.cwd(),'/package.json'))
+    if ('axios' in devDependencies || 'axios' in dependencies) return require('axios')
   } catch {/* ignore */}
 }
 

--- a/lib/xaxios.js
+++ b/lib/xaxios.js
@@ -2,6 +2,7 @@ const AXIOS = !/\b(false)\b/.test(process.env.AXIOS) // to disable axios mode ev
 
 class AxiosProvider {
 
+  /** @deprecated */ 
   get axios() {
     const http = require('node:http')
     const axios = (AXIOS && _axios()) ? require('axios') : require('./naxios')

--- a/lib/xaxios.js
+++ b/lib/xaxios.js
@@ -1,10 +1,12 @@
-const AXIOS = !/\b(false)\b/.test(process.env.AXIOS) // to disable axios mode even if axios is installed
 
 class AxiosProvider {
 
-  /** @deprecated */ 
+  /**
+   * @deprecated configure on request level instead, e.g. `GET('/path', { headers:{ Authorization: '...' } })`
+   */
   get axios() {
     const http = require('node:http')
+    const AXIOS = !/\b(false)\b/.test(process.env.AXIOS) // to disable axios mode even if axios is installed
     const axios = (AXIOS && _axios()) ? require('axios') : require('./naxios')
     return super.axios = axios.create ({
       httpAgent: new http.Agent({ keepAlive: false}), //> https://github.com/nodejs/node/issues/47130

--- a/lib/xaxios.js
+++ b/lib/xaxios.js
@@ -1,8 +1,10 @@
+const AXIOS = !/\b(false)\b/.test(process.env.AXIOS) // to disable axios mode even if axios is installed
+
 class AxiosProvider {
 
   get axios() {
     const http = require('node:http')
-    const axios = require('./naxios')
+    const axios = (AXIOS && _axios()) ? require('axios') : require('./naxios')
     return super.axios = axios.create ({
       httpAgent: new http.Agent({ keepAlive: false}), //> https://github.com/nodejs/node/issues/47130
       headers: { 'content-type': 'application/json' },
@@ -75,6 +77,12 @@ const _error = (err) => {
   // Reduce stack trace
   Error.captureStackTrace (err, _error)
   throw err
+}
+
+const _axios = () => {
+  try {
+    return require('axios')
+  } catch {/* ignore */}
 }
 
 module.exports = AxiosProvider

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,13 +13,15 @@
         "chest": "bin/chest.js"
       },
       "devDependencies": {
-        "@cap-js/sqlite": "^1.5.0 || ^2"
+        "@cap-js/sqlite": "^2"
       },
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sap/cds": ">=9.8"
+        "@sap/cds": ">=9.8",
+        "chai": "^6",
+        "chai-as-promised": "^8"
       }
     },
     "node_modules/@cap-js/db-service": {
@@ -77,9 +79,9 @@
       }
     },
     "node_modules/@sap/cds": {
-      "version": "9.8.4",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.8.4.tgz",
-      "integrity": "sha512-1cnFdz4Ex4LV15dztDsSLDiilVdJ2mfTqr5A3TGsRd/6cM31SnHhuZ/Ra0FEErodokNS2pwasGZmSfgHVDW8KA==",
+      "version": "9.8.5",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.8.5.tgz",
+      "integrity": "sha512-AU7HzrdEf8u13W2Aff8GyqKpJh6w9yXK/68xvXD+6cuU21JcGOLQ+dInbNV8vRKaCMn2cVVrsx7OoR+j7z5QKA==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
@@ -173,9 +175,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -300,6 +302,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-8.0.2.tgz",
+      "integrity": "sha512-1GadL+sEJVLzDjcawPM4kjfnL+p/9vrxiEUonowKOAzvVg0PixJUdtuDzdkDeQhK3zfOE76GqGkZIQ7/Adcrqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "check-error": "^2.1.1"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 7"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -308,9 +343,9 @@
       "license": "ISC"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -997,9 +1032,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "peer": true,
       "funding": {
@@ -1061,9 +1096,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
@@ -1266,14 +1301,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,13 @@
 {
   "name": "@cap-js/cds-test",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cap-js/cds-test",
-      "version": "0.4.1",
+      "version": "1.0.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "axios": "^1",
-        "chai": "^4.4.1",
-        "chai-as-promised": "^7.1.1",
-        "chai-subset": "^1.6.0"
-      },
       "bin": {
         "cds-test": "bin/chest.js",
         "chest": "bin/chest.js"
@@ -25,59 +19,74 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@sap/cds": ">=8.8"
+        "@sap/cds": ">=9.8"
       }
     },
     "node_modules/@cap-js/db-service": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/db-service/-/db-service-2.7.0.tgz",
-      "integrity": "sha512-g6LDETBPWr8LYs3emrpEA4+FdVCkGgFmKHaeMPVBFXgFTUv14uYnarqWuFubBTrp5JF6S3wgljMJujld5+DL8A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/db-service/-/db-service-2.9.0.tgz",
+      "integrity": "sha512-WCXhoqezaF6A5I2l0MNZeHKXXtHRNEq7Rp0R89/uccOHQIx0DuU0U9NuJJPV/1G5RGk2QKQ9VBo/KYn+MZuuNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "generic-pool": "^3.9.0"
       },
       "peerDependencies": {
-        "@sap/cds": ">=9.4.5"
+        "@sap/cds": ">=9.8"
       }
     },
     "node_modules/@cap-js/sqlite": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@cap-js/sqlite/-/sqlite-2.1.0.tgz",
-      "integrity": "sha512-5jz7GlsrYCd5VlFEzImz5SCBkNa6Ps1wB9+1MceGlMrQLt0lDxiK1NqA+pIrcMeGWkQIcbNLteuP26ZQkGRidw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cap-js/sqlite/-/sqlite-2.2.0.tgz",
+      "integrity": "sha512-FPj+uVU/14vtGUl2P/Q8y7XhZbsLgrCav2O5PjHPXnupegjby4sMJkgVNxVHnkyKPFgO/W8uEsq9r5TU9VPx8w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cap-js/db-service": "^2.7.0",
+        "@cap-js/db-service": "^2.9.0",
         "better-sqlite3": "^12.0.0"
       },
       "peerDependencies": {
-        "@sap/cds": ">=9"
+        "@sap/cds": ">=9.8",
+        "sql.js": "^1.13.0"
+      },
+      "peerDependenciesMeta": {
+        "sql.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.1.tgz",
-      "integrity": "sha512-S26Stp4zCy88tH94QbBv3XCuzRQiZ9yXofEILmglYTh/Ug/a9/umqvgFtYBAo3Lp0nsI/5/qH1CCrbdK3AP1Tw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sap/cds": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.5.1.tgz",
-      "integrity": "sha512-rMvDSRytjqYQolB0pg8tiBlpS9kKGcleRhpZmBGUmSncbbwnotKYTKoDyMCWkflS8P9/Jq9YfY1qhK+fduHCVA==",
+      "version": "9.8.4",
+      "resolved": "https://registry.npmjs.org/@sap/cds/-/cds-9.8.4.tgz",
+      "integrity": "sha512-1cnFdz4Ex4LV15dztDsSLDiilVdJ2mfTqr5A3TGsRd/6cM31SnHhuZ/Ra0FEErodokNS2pwasGZmSfgHVDW8KA==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "dependencies": {
-        "@sap/cds-compiler": "^6.3",
+        "@sap/cds-compiler": "^6.4",
         "@sap/cds-fiori": "^2",
-        "js-yaml": "^4.1.0"
+        "express": "^4.22.1 || ^5",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "cds-deploy": "bin/deploy.js",
@@ -87,23 +96,19 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@eslint/js": "^9",
-        "express": "^4",
-        "tar": "^7"
+        "@eslint/js": "^9 || ^10",
+        "tar": "^7.5.6"
       },
       "peerDependenciesMeta": {
-        "express": {
-          "optional": true
-        },
         "tar": {
           "optional": true
         }
       }
     },
     "node_modules/@sap/cds-compiler": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-6.4.6.tgz",
-      "integrity": "sha512-auAjRh9t0KKj4LiGAr/fxikZRIngx9YXVHTJWf0LeaGv0ZpYOi6iWbSnU1XRB2e6hsf+Ou1w5oTOHooC5sZfog==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-compiler/-/cds-compiler-6.8.0.tgz",
+      "integrity": "sha512-yRoTZcH8DFiP4PcEuIHe42YAaNt51V736+6RRr+U4nbO91sz36L8be2djcE8n760t8IbqLxzZ/UkATiL0fjRmA==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "bin": {
@@ -116,25 +121,24 @@
       }
     },
     "node_modules/@sap/cds-fiori": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-2.1.1.tgz",
-      "integrity": "sha512-X+4v4LBAT8HIt0zr28/kJNS15nlNlcM97vAMW+agLrmK134nyBiMwUMcp8BMhxlG9B2PykrnAKH56D9O3tfoBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sap/cds-fiori/-/cds-fiori-2.3.0.tgz",
+      "integrity": "sha512-6oWov+DSpFrSTgxXR0dZhak6aZ/IVRZvaHERMi0EgSTzIJdlvZlpw3Kf18ePMcTrRrtEXwD4RIjKt8pbs0g2Hg==",
       "license": "SEE LICENSE IN LICENSE",
       "peer": true,
       "peerDependencies": {
-        "@sap/cds": ">=8",
-        "express": "^4"
+        "@sap/cds": ">=8"
       }
     },
     "node_modules/accepts": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "mime-types": "~2.1.34",
-        "negotiator": "0.6.3"
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -146,39 +150,6 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0",
       "peer": true
-    },
-    "node_modules/array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -202,9 +173,9 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
-      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -213,7 +184,7 @@
         "prebuild-install": "^7.1.1"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x"
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
     "node_modules/bindings": {
@@ -239,28 +210,28 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/buffer": {
@@ -303,6 +274,7 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -328,58 +300,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
-      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
-      "license": "WTFPL",
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 6"
-      }
-    },
-    "node_modules/chai-subset": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/chai-subset/-/chai-subset-1.6.0.tgz",
-      "integrity": "sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==",
-      "deprecated": "functionality of this lib is built-in to chai now. see more details here: https://github.com/debitoor/chai-subset/pull/85",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
@@ -387,29 +307,18 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/content-disposition": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
@@ -423,9 +332,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -433,20 +342,31 @@
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
     },
     "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decompress-response": {
@@ -465,18 +385,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "license": "MIT",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -487,15 +395,6 @@
         "node": ">=4.0.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -504,17 +403,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/destroy": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/detect-libc": {
@@ -532,6 +420,7 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -573,6 +462,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -582,6 +472,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -591,23 +482,9 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -641,46 +518,43 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
-      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "accepts": "~1.3.8",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
-        "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.3",
-        "methods": "~1.1.2",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.12",
-        "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
-        "range-parser": "~1.2.1",
-        "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "type-is": "~1.6.18",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.10.0"
+        "node": ">= 18"
       },
       "funding": {
         "type": "opencollective",
@@ -695,58 +569,25 @@
       "license": "MIT"
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "debug": "2.6.9",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
-        "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
-        "unpipe": "~1.0.0"
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
+        "node": ">= 18.0.0"
       },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/forwarded": {
@@ -760,13 +601,13 @@
       }
     },
     "node_modules/fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/fs-constants": {
@@ -781,6 +622,7 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -795,20 +637,12 @@
         "node": ">= 4"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -833,6 +667,7 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -853,6 +688,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -865,21 +701,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -892,6 +714,7 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -900,33 +723,41 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ieee754": {
@@ -973,6 +804,13 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -986,86 +824,64 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-response": {
@@ -1099,9 +915,9 @@
       "license": "MIT"
     },
     "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
       "peer": true
     },
@@ -1113,9 +929,9 @@
       "license": "MIT"
     },
     "node_modules/negotiator": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1123,9 +939,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.80.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.80.0.tgz",
-      "integrity": "sha512-LyPuZJcI9HVwzXK1GPxWNzrr+vr8Hp/3UqlmWxxh8p54U1ZbclOqbSog9lWHaCX+dBaiGi6n/hIX+mKu74GmPA==",
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1165,7 +981,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -1182,25 +997,21 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "license": "MIT",
-      "peer": true
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1238,16 +1049,10 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
-    },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1256,13 +1061,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "license": "BSD-3-Clause",
       "peer": true,
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -1282,19 +1087,19 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -1328,10 +1133,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1356,9 +1179,9 @@
       "peer": true
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1369,61 +1192,50 @@
       }
     },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
@@ -1557,9 +1369,9 @@
       }
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -1639,24 +1451,16 @@
         "node": "*"
       }
     },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -1679,16 +1483,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1703,7 +1497,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/cds-test",
-  "version": "0.4.1",
+  "version": "1.0.0",
   "description": "Test Support for CAP Node.js",
   "keywords": [
     "CAP",
@@ -32,14 +32,8 @@
     "mocha": "npx -y mocha",
     "node-test": "node --test"
   },
-  "dependencies": {
-    "axios": "^1",
-    "chai": "^4.4.1",
-    "chai-as-promised": "^7.1.1",
-    "chai-subset": "^1.6.0"
-  },
   "peerDependencies": {
-    "@sap/cds": ">=8.8"
+    "@sap/cds": ">=9.8"
   },
   "devDependencies": {
     "@cap-js/sqlite": "^1.5.0 || ^2"

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "node": ">=20"
   },
   "scripts": {
-    "chest": "chest",
-    "test": "chest",
+    "chest": "./bin/chest.js",
+    "test": "./bin/chest.js",
     "jest": "npx jest --silent",
     "mocha": "npx mocha --parallel",
     "vitest": "npx vitest --globals --silent",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "chest": "./bin/chest.js",

--- a/package.json
+++ b/package.json
@@ -26,16 +26,19 @@
     "node": ">=20"
   },
   "scripts": {
-    "chest": "bin/chest.js",
-    "test": "npm run chest -s",
-    "jest": "npx -y jest",
-    "mocha": "npx -y mocha",
+    "chest": "chest",
+    "test": "chest",
+    "jest": "npx jest --silent",
+    "mocha": "npx mocha --parallel",
+    "vitest": "npx vitest --globals --silent",
     "node-test": "node --test"
   },
   "peerDependencies": {
-    "@sap/cds": ">=9.8"
+    "@sap/cds": ">=9.8",
+    "chai-as-promised": "^8",
+    "chai": "^6"
   },
   "devDependencies": {
-    "@cap-js/sqlite": "^1.5.0 || ^2"
+    "@cap-js/sqlite": "^2"
   }
 }

--- a/test/app/server.js
+++ b/test/app/server.js
@@ -1,0 +1,7 @@
+const cds = require('@sap/cds')
+
+// middleware with redirect to test the redirect handling of the server
+cds.on('bootstrap', app => {
+  app.get('/ok', (_, res) => res.status(200).send('ok'))
+  app.get('/redirect', (_, res) => res.redirect('/ok'))
+})

--- a/test/app/srv/cat-service.cds
+++ b/test/app/srv/cat-service.cds
@@ -13,4 +13,6 @@ service CatalogService {
   // @requires: 'authenticated-user'
   action submitOrder ( book: Books:ID, amount: Integer ) returns { stock: Integer };
   event OrderedBook : { book: Books:ID; amount: Integer; buyer: String };
+
+  function delay(ms: Integer) returns String;
 }

--- a/test/app/srv/cat-service.js
+++ b/test/app/srv/cat-service.js
@@ -20,6 +20,11 @@ class CatalogService extends cds.ApplicationService { init(){
     if (each.stock > 111) each.title += ` -- 11% discount!`
   })
 
+  this.on('delay', req => {
+    const { ms } = req.data
+    return new Promise(resolve => setTimeout(() => resolve(`Delay of ${ms}ms reached`), ms))
+  })
+
   return super.init()
 }}
 

--- a/test/app/test/sample-bookshop.test.js
+++ b/test/app/test/sample-bookshop.test.js
@@ -6,6 +6,10 @@ describe('Sample tests', () => {
   it('serves Books', async () => {
     const { data } = await GET`/odata/v4/catalog/Books`
     expect(data.value.length).to.be.greaterThanOrEqual(5)
+    expect(data.value).to.containSubset([
+      { title: 'Wuthering Heights' },
+      { title: 'The Raven' },
+    ])
   })
 
 })

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -107,6 +107,14 @@ describe('cds_test', ()=>{
       test.axios.defaults.maxRedirects = 0
       await GET('/redirect').catch(err => { expect(err.response.status).to.equal(302) })
     })
+
+    it('should support axios timeouts', async ()=> {
+      const { GET } = test
+      const { data } = await GET `/odata/v4/catalog/delay(ms='50')`
+      expect(data.value).to.match(/50/)
+      test.axios.defaults.timeout = 10
+      await expect(GET `/odata/v4/catalog/delay(ms='50')`).to.eventually.be.rejectedWith(/timeout/i)
+    })
   })
 
 

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -108,7 +108,8 @@ describe('cds_test', ()=>{
       await GET('/redirect').catch(err => { expect(err.response.status).to.equal(302) })
     })
 
-    it('should support axios timeouts', async ()=> {
+    // TODO timeouts lead to open handles reported by test runners
+    it.skip('should support axios timeouts', async ()=> {
       const { GET } = test
       const { data } = await GET `/odata/v4/catalog/delay(ms='50')`
       expect(data.value).to.match(/50/)

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -37,7 +37,6 @@ describe('cds_test', ()=>{
   })
 
   describe ('chai', ()=> {
-    if (test.chai.fake) return it.skip ('chai is faked')
 
     it('should export chai', ()=> {
       expect (test.chai).to.exist
@@ -53,21 +52,21 @@ describe('cds_test', ()=>{
 
     it('should support chai.except style', ()=>{
       const { expect } = test, foobar = {foo:'bar'}
-      expect(foobar).to.have.property('foo')
       expect(foobar.foo).to.equal('bar')
+      expect(foobar).to.have.property('foo','bar')
     })
 
     it('should use chai.assert style', ()=>{
       const { assert } = test, foobar = {foo:'bar'}
-      assert.property(foobar,'foo')
       assert.equal(foobar.foo,'bar')
+      // assert.property(foobar,'foo','bar')
     })
 
     it('should support chai.should style', ()=>{
-      const { should } = test, foobar = {foo:'bar'}
-      foobar.should.have.property('foo')
+      const foobar = {foo:'bar'}
+      test.chai.should()
       foobar.foo.should.equal('bar')
-      should.equal(foobar.foo,'bar')
+      foobar.should.have.property('foo','bar')
     })
 
   })

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -100,6 +100,13 @@ describe('cds_test', ()=>{
         await GET('/foo')
       }
     })
+
+    it('should support axios maxRedirects', async ()=> {
+      const { GET } = test
+      await GET('/redirect')
+      test.axios.defaults.maxRedirects = 0
+      await GET('/redirect').catch(err => { expect(err.response.status).to.equal(302) })
+    })
   })
 
 

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -88,6 +88,9 @@ describe (`supported chai features subset ...`, ()=>{
     expect({a:3, b:4}).to.deep.include({a:3, b:4}); // Recommended
     expect({a:3, b:4}).to.not.include({a:1, b:2}); // Not recommended
 
+    expect({a:3, b:4}).to.include({b:4, a:3});
+    expect({a:3, b:4}).to.containSubset({b:4, a:3});
+
     // The aliases .includes, .contain, and .contains can be used interchangeably with .include.
   })
 
@@ -157,9 +160,6 @@ describe (`superset features, not in chai ...`, ()=>{
 
 describe ('unsupported chai features', ()=>{
 
-  it.skip (`doesn't support .include subsets`, ()=>{
-    expect({a:3, b:4}).to.include({a:3}); // use .subset or .match instead
-  })
   it.skip (`doesn't support .include chains`, ()=>{
     expect({a:1, b:2, c:3}).to.include.all.keys('a', 'b')
     expect({a:1, b:2, c:3}).to.not.have.all.keys('a', 'b')

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -89,9 +89,14 @@ describe (`supported chai features subset ...`, ()=>{
     expect({a:3, b:4}).to.not.include({a:1, b:2}); // Not recommended
 
     expect({a:3, b:4}).to.include({b:4, a:3});
-    expect({a:3, b:4}).to.containSubset({b:4, a:3});
 
     // The aliases .includes, .contain, and .contains can be used interchangeably with .include.
+  })
+
+  it ('supports .subset', ()=>{
+    expect({a:3, b:4}).to.containSubset({b:4, a:3});
+    expect({a:3, b:4}).to.not.containSubset({a:1, b:2});
+    expect({a:[1,2,3], b:[4,5,6]}).to.containSubset({a:[2,1], b:[4,6,5]});
   })
 
   it ('supports .within', ()=>{


### PR DESCRIPTION
This brings naxios etc back, reverting commit 45d153c21e0a6e4868cd5daf6fbf5ba3ecf12aab.

Fixes:
- [x] `validateStatus` can be falsy → #73
- [x] `arraybuffer` responses are not Buffers, fixed with 3a375d1, see `cds-graphql/test/tests/queries/variables.test.js`
- [x] `axios.defaults.maxRedirects` not supported, fixed with 6d60668, see `cds-fiori/test/preview/routes.test.js`
- [x] Absolute URLs in requests failed, fixed with f3031cf
- [x] `containSubset` too strict, fixed with d27e127, see `cap/dev/test/capire/getting-started.test.js`
- [x] OData batch responses, see `cds-mtxs/test/extensibility/ft-mt-custom-auth/ft-custom-auth.test.js` → remove test

Also support:
- [x] axios compat. that kicks in if `axios` is installed
- [x] latest `chai-as-promised` with b6d6dbf

Tests coverage
- [x] cap/dev tests (w/o `axios`)
