### PR TITLE
fix: follow symlinks during test file discovery

### DIFF
--- a/bin/chest.js
+++ b/bin/chest.js
@@ -82,7 +82,7 @@ async function fetch (argv,o) {
   const ignore = /^(\..*|node_modules|_out)$/
   const files = []
   const _read = fs.promises.readdir
-  const _isdir = x => fs.lstatSync(x).isDirectory()
+  const _isdir = x => fs.statSync(x).isDirectory()
   await async function _visit (dir) {
     const entries = await _read (dir)
     return Promise.all (entries.map (each => {


### PR DESCRIPTION
Use `statSync` instead of `lstatSync` so that symlinked directories
are traversed when searching for test files.

`lstatSync` returns stats about the symlink entry itself — for a
symlink pointing to a directory, `isDirectory()` returns `false`,
so the directory is never traversed.

This breaks projects that use symlinks to share test suites across
workspaces, e.g. `hana/test/compliance → ../../test` in cds-dbs.

```js
fs.statSync('hana/test/compliance'):
  isDirectory()    → true    (stats of ../../test/, which IS a directory)
  isSymbolicLink() → false

fs.lstatSync('hana/test/compliance'):
  isDirectory()    → false   (stats of the symlink entry, which is NOT a directory)
  isSymbolicLink() → true
```

See: https://github.com/cap-js/cds-dbs/pull/1583