### PR TITLE
chore: cds.test --with-mocks

### DIFF
--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -25,7 +25,7 @@ class Test extends require('./xaxios') {
     switch (folder_or_cmd) {
       case 'serve': break // nothing to do as all arguments are given
       case 'run': if (args.length > 0) args.unshift ('--project'); break
-      default: this.in(folder_or_cmd); args.push ('--in-memory?')
+      default: this.in(folder_or_cmd); args.push ('--in-memory?','--with-mocks')
     }
 
     // launch cds server...
@@ -143,10 +143,10 @@ class Test extends require('./xaxios') {
   }
 
 
-  /** 
+  /**
    * Returns `chai.expect` function, or a lookalike.
-   * @returns {import('./expect')} 
-   */ 
+   * @returns {import('./expect')}
+   */
   get expect() { return this.chai.expect }
 
   /** @deprecated */ get assert() { return this.chai.assert }
@@ -163,13 +163,13 @@ Object.setPrototypeOf (exports, Test.prototype)
 
 
 /**
- * Provide same global functions for node --test, jest, mocha, and vitest, 
- * to allow running tests with any of these runners without changing test code. 
- * Note that cds.test() must be called before importing test code to ensure the 
+ * Provide same global functions for node --test, jest, mocha, and vitest,
+ * to allow running tests with any of these runners without changing test code.
+ * Note that cds.test() must be called before importing test code to ensure the
  * correct runner is detected and supported.
  */
 exports.runner ??= function _support_jest_and_mocha() {
-  
+
   // Determine the test runner we are running in...
   const runner = (
     global.cds?.repl              ? 'repl' :
@@ -180,15 +180,15 @@ exports.runner ??= function _support_jest_and_mocha() {
     /* else */                      'node-test'
   )
 
-  // Load support for the detected runner, which will define global test 
+  // Load support for the detected runner, which will define global test
   // functions like describe(), it(), expect(), ...
   require ('./fixtures/'+runner+'.js')
 
-  // Silence test output by default if not explicitly disabled, 
-  // to avoid cluttering CI logs, but allow it for mocha which 
+  // Silence test output by default if not explicitly disabled,
+  // to avoid cluttering CI logs, but allow it for mocha which
   const { CDS_TEST_SILENT } = process.env; if (/true|y|1/.test(CDS_TEST_SILENT)) exports.silent()
   else if (CDS_TEST_SILENT !== 'false' && runner === 'node-test') exports.silent()
   else if (CDS_TEST_SILENT !== 'false' && runner === 'mocha') exports.silent()
-  
+
   return runner
 }()

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "@sap/cds": ">=9.8",
     "chai-as-promised": "^8",
     "chai": "^6"
+  },
+  "devDependencies": {
+    "@cap-js/sqlite": "^2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "@sap/cds": ">=9.8",
     "chai-as-promised": "^8",
     "chai": "^6"
-  },
-  "devDependencies": {
-    "@cap-js/sqlite": "^2"
   }
 }

--- a/test/expect.test.js
+++ b/test/expect.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-if (typeof describe === 'undefined') ({ describe, it } = require('node:test'))
+if (!global.describe) ({ describe, it } = require('node:test'))
 const expect = require('../lib/expect')
 
 describe (`supported chai features subset ...`, ()=>{

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,4 @@
+export default { test: {
+  globals: true,
+  silent: true
+}}


### PR DESCRIPTION
1. Start servers `--with-mocks` by default → same as `cds watch`
2. Fixed the runner-independent access to `describe` in expect.test → errored w/ vitest
3. Added vitest.config.js

Ad 1: Avoids projects like xtravels to always have to specify `--with-mocks` in their tests. Which wasn't on our radar screen as we so far didn't do much service integration in our tests and samples, which changed since ~2 months.
