### PR TITLE
fix: .to.be.fullfilled/rejected must return this

### DIFF
--- a/lib/expect.js
+++ b/lib/expect.js
@@ -260,8 +260,15 @@ class Chai extends Core {
   get greaterThanOrEqual() { return this.gte }
 
   get throw() { return this.throws }
-  get fulfilled() { return this.not.rejectsWith() }
-  get rejected() { return this.rejectsWith() }
+  get fulfilled() {
+    this._ = this.not.rejectsWith()
+    delete this._not
+    return this
+  }
+  get rejected() {
+    this._ = this.rejectsWith()
+    return this
+  }
   get rejectedWith() { return this.rejectsWith }
 }
 


### PR DESCRIPTION
The former implementation was plain wrong, and spoiled usages like that: 
```js
await expect (deleted.missing.foo.locally) .to.be.rejected .and.eventually.containSubset ({ code:404 })
```