### PR TITLE
fix: fulfilled and rejected can be awaited

### DIFF
--- a/lib/expect.js
+++ b/lib/expect.js
@@ -261,12 +261,14 @@ class Chai extends Core {
 
   get throw() { return this.throws }
   get fulfilled() {
-    this._ = this.not.rejectsWith()
+    const promise = this._ = this.not.rejectsWith()
     delete this._not
+    this.then = (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected)
     return this
   }
   get rejected() {
-    this._ = this.rejectsWith()
+    const promise = this._ = this.rejectsWith()
+    this.then = (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected)
     return this
   }
   get rejectedWith() { return this.rejectsWith }


### PR DESCRIPTION
follow-up of https://github.com/cap-js/cds-test/pull/92

`fulfilled` and `rejected` return `this` for chaining but can also be awaited