### PR TITLE
fix: ensure most recent cds model before deletion

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -10,6 +10,7 @@ exports.deploy = async function (db) {
 
 exports.delete = async function (db) {
   if (!db) db = await cds.connect.to('db')
+  if (cds.model) db.model = cds.model
   const deletes = _deletes4 (db.model)
   if (deletes.length) await db.run(deletes)
 }


### PR DESCRIPTION
Currently, `db.model` that is used as input for `_deletes4` is not guaranteed to match the effective model. The effective model could have been modified during `.on('loaded')`, e.g. when `@cap-js/cds-test` is used in combination with `@cap-js/data-privacy`, where the model is [enhanced](https://github.com/cap-js/data-privacy/blob/4f414d6adcd3e993e6033de533b59fccf17c7b84/lib/csn-enhancements/index.js#L22) in such a handler.