### PR TITLE
fix: pass debug flag to runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - `Buffer` request bodies are no longer serialized via `JSON.stringify()`
+- In `chest`-powered tests, `inspectPort` configuration will be passed to `node:test.run(...)` when debugging
+- In `chest`-powered tests, `concurrency` of `node:test.run(...)` will be limitted to `1` to enable debugging
 
 ## [1.0.1] - 2026-04-29
 

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -62,10 +62,17 @@ async function test (argv,o) {
   if (o.list) return list (o.files)
   if (o.skip) process.env._chest_skip = o.skip
   if (o.files.length > 1) console.log (DIMMED,`\nRunning ${o.files.length} test suites...`, RESET)
+  
+  const debugging = process.execArgv.some(a => /^--inspect/.test(a))
+  if (debugging && process.execArgv.some(a => /^--inspect-brk/.test(a))) {
+    require('node:inspector').open(process.debugPort) // resume parent so workers can start
+  }
+
   const test = require('node:test').run({ ...o,
     execArgv: [ '--require', require.resolve('../lib/fixtures/node-test.js') ],
+    inspectPort: debugging ? process.debugPort + 1 : undefined,
     timeout: +o.timeout || undefined,
-    concurrency: +o.workers || true,
+    concurrency: debugging ? 1 : (+o.workers || true),
     forceExit: true,
     testSkipPatterns: regex4 (o.skip), skip: false,
     testNamePatterns: regex4 (o.only), only: false,

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -64,9 +64,9 @@ async function test (argv,o) {
   if (o.files.length > 1) console.log (DIMMED,`\nRunning ${o.files.length} test suites...`, RESET)
   
   const debugging = process.execArgv.some(a => /^--inspect/.test(a))
-  if (debugging && process.execArgv.some(a => /^--inspect-brk/.test(a))) {
-    require('node:inspector').open(process.debugPort) // resume parent so workers can start
-  }
+  // if (debugging && process.execArgv.some(a => /^--inspect-brk/.test(a))) {
+  //   require('node:inspector').open(process.debugPort) // resume parent so workers can start
+  // }
 
   const test = require('node:test').run({ ...o,
     execArgv: [ '--require', require.resolve('../lib/fixtures/node-test.js') ],

--- a/bin/chest.js
+++ b/bin/chest.js
@@ -53,6 +53,9 @@ const os = require('os'), home = os.userInfo().homedir
 const path = require('node:path')
 const fs = require('node:fs')
 
+const DEBUGGING = process.env.VSCODE_INSPECTOR_OPTIONS 
+  || process.argv.concat(process.execArgv).some(ele => ele.startsWith('--inspect'))
+
 async function test (argv,o) {
   if (o.help || argv == '?') return console.log (USAGE)
   if (o.recent) o = { ...o, ...recent().options }
@@ -62,17 +65,12 @@ async function test (argv,o) {
   if (o.list) return list (o.files)
   if (o.skip) process.env._chest_skip = o.skip
   if (o.files.length > 1) console.log (DIMMED,`\nRunning ${o.files.length} test suites...`, RESET)
-  
-  const debugging = process.execArgv.some(a => /^--inspect/.test(a))
-  // if (debugging && process.execArgv.some(a => /^--inspect-brk/.test(a))) {
-  //   require('node:inspector').open(process.debugPort) // resume parent so workers can start
-  // }
 
   const test = require('node:test').run({ ...o,
     execArgv: [ '--require', require.resolve('../lib/fixtures/node-test.js') ],
-    inspectPort: debugging ? process.debugPort + 1 : undefined,
+    inspectPort: DEBUGGING ? process.debugPort + 1 : undefined,
     timeout: +o.timeout || undefined,
-    concurrency: debugging ? 1 : (+o.workers || true),
+    concurrency: DEBUGGING ? 1 : (+o.workers || true),
     forceExit: true,
     testSkipPatterns: regex4 (o.skip), skip: false,
     testNamePatterns: regex4 (o.only), only: false,


### PR DESCRIPTION
Currently, debug flags will not correctly be applied to node-test workers. In a debug terminal, tests hang because flag `--inspect-brk` may be used, rather than `--inspect`; when no connection with the debugger is made - the test hangs. This can be mitigated by limiting to a single worker (i.e. `'node:test'.run`) when debugging; and passing a `inspectPort` configuration. 

Verified by running chest tests in a VSCode Javascript Debug Terminal using `npm t some.test.js`. 