### PR TITLE
feat: remove `log` capture API

### DIFF
--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -105,27 +105,6 @@ class Test extends require('./xaxios') {
 
 
   /**
-   * Captures console.log output.
-   */
-  log (_capture) {
-    const {console} = global, {format} = require('util')
-    const log = { output: '' }
-    beforeAll (()=> global.console = { __proto__: console,
-      log: _capture ??= (..._) => log.output += format(..._)+'\n',
-      info: _capture,
-      warn: _capture,
-      debug: _capture,
-      trace: _capture,
-      error: _capture,
-      timeEnd: _capture, time: ()=>{},
-    })
-    afterAll (log.release = ()=>{ log.output = ''; global.console = console })
-    afterEach (log.clear = ()=>{ log.output = '' })
-    return log
-  }
-
-
-  /**
    * Silences all console log output, e.g.: CDS_TEST_SILENT=y jest/mocha ...
    */
   silent(){

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -119,34 +119,6 @@ describe('cds_test', ()=>{
   })
 
 
-  describe ('logs', ()=> {
-
-    let log = test.log()
-
-    it('should support capturing logs', ()=> {
-      expect (log.output).to.exist
-      expect (log.output.length).to.equal(0)
-      console.log('foo') // eslint-disable-line no-console
-      console.log('bar') // eslint-disable-line no-console
-      expect (log.output.length).to.be.greaterThan(0)
-      expect (log.output).to.contain('foo')
-      expect (log.output).to.equal('foo\nbar\n')
-    })
-
-    it('should support log.clear()', ()=> {
-      log.clear()
-      expect (log.output).to.equal('')
-    })
-
-    it('should support log.release()', ()=> {
-      log.release()
-      console.log('foobar') // eslint-disable-line no-console
-      expect (log.output).to.equal('')
-    })
-
-  })
-
-
   describe('data', () => {
     beforeEach (test.data.reset)
 


### PR DESCRIPTION
If a test is written that depends on the log output of the application it is an indicator of earlier mistakes.