### PR TITLE
feat: remove `sleep` API

### DIFF
--- a/lib/cds-test.js
+++ b/lib/cds-test.js
@@ -11,7 +11,6 @@ class Test extends require('./xaxios') {
    * Allows: const { GET, expect, test } = cds.test()
    */
   get test() { return this }
-  get sleep() { return super.sleep = require('node:timers/promises').setTimeout }
   get data() { return super.data = require('./data') }
   get cds() { return cds }
 

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -23,14 +23,6 @@ describe('cds_test', ()=>{
     expect (url).to.match (/http:\/\/localhost:/)
   })
 
-  it('should support cds and sleep', async()=> {
-    const { cds:_cds, sleep } = test, t0 = Date.now()
-    expect (_cds) .to.equal (cds)
-    await sleep(12)
-    expect (Date.now()) .to.be.greaterThanOrEqual (t0+11)
-  })
-
-
   it('should support mocha', ()=> {
     expect (global.before).to.exist
     expect (global.after).to.exist


### PR DESCRIPTION
A test that is using `sleep` indicates that it is waiting for something to happen. The proper solution to that problem is to wait directly for the thing to happen. The only value a `sleep` API provides is the ability to waste time.