### PR TITLE
fix(naxios): send Buffer request bodies as raw bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
-- `Buffer` and `Readable` stream request bodies are no longer serialized via `JSON.stringify()` and `Content-Type` header is not forcibly overridden to `application/json`
+- `Buffer` request bodies are no longer serialized via `JSON.stringify()`
 
 ## [1.0.1] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [1.0.2] - 2026-08-04
+
+### Fixed
+
+- `Buffer` and `Readable` stream request bodies are no longer serialized via `JSON.stringify()` and `Content-Type` header is not forcibly overridden to `application/json`
+
 ## [1.0.1] - 2026-04-29
 
 ### Fixed

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -52,11 +52,13 @@ class Naxios {
     if (o.maxRedirects === 0) { o.redirect = 'manual'; delete o.maxRedirects }
     // TODO investigate why timeout support leads to open handles reported by test runners
     // if (o.timeout) { o.signal = AbortSignal.timeout(o.timeout); delete o.timeout }// eslint-disable-line no-undef
+    const isBinary = Buffer.isBuffer(data) || data instanceof Readable
     if (data) o.body =
       typeof data === 'string' ? data :
-      data instanceof Readable ? data :
+      isBinary ? data :
       JSON.stringify(data)
-    if (typeof data === 'object' && !o.headers.has('Content-Type')) o.headers.set('Content-Type', 'application/json')
+    if (typeof data === 'object' && !isBinary && !o.headers.has('Content-Type'))
+      o.headers.set('Content-Type', 'application/json')
     if (!url.startsWith('http')) url = (o.baseURL||'') + (o.path||'') + (url[0]==='/'?'':'/') + url
     if (params) url += '?' + new URLSearchParams (params)
     o.url = url

--- a/lib/naxios.js
+++ b/lib/naxios.js
@@ -52,13 +52,12 @@ class Naxios {
     if (o.maxRedirects === 0) { o.redirect = 'manual'; delete o.maxRedirects }
     // TODO investigate why timeout support leads to open handles reported by test runners
     // if (o.timeout) { o.signal = AbortSignal.timeout(o.timeout); delete o.timeout }// eslint-disable-line no-undef
-    const isBinary = Buffer.isBuffer(data) || data instanceof Readable
     if (data) o.body =
       typeof data === 'string' ? data :
-      isBinary ? data :
+      data instanceof Readable ? data :
+      Buffer.isBuffer(data) ? data :
       JSON.stringify(data)
-    if (typeof data === 'object' && !isBinary && !o.headers.has('Content-Type'))
-      o.headers.set('Content-Type', 'application/json')
+    if (typeof data === 'object' && !o.headers.has('Content-Type')) o.headers.set('Content-Type', 'application/json')
     if (!url.startsWith('http')) url = (o.baseURL||'') + (o.path||'') + (url[0]==='/'?'':'/') + url
     if (params) url += '?' + new URLSearchParams (params)
     o.url = url

--- a/test/app/server.js
+++ b/test/app/server.js
@@ -1,7 +1,16 @@
 const cds = require('@sap/cds')
+const express = require('express')
 
 // middleware with redirect to test the redirect handling of the server
 cds.on('bootstrap', app => {
   app.get('/ok', (_, res) => res.status(200).send('ok'))
   app.get('/redirect', (_, res) => res.redirect('/ok'))
+
+  // Echoes the raw request body back as application/octet-stream.
+  app.post('/echo-binary',
+    express.raw({ type: 'application/octet-stream', limit: '10mb' }),
+    (req, res) => {
+      res.set('Content-Type', 'application/octet-stream')
+      res.status(200).send(req.body)
+    })
 })

--- a/test/cds-test.test.js
+++ b/test/cds-test.test.js
@@ -111,6 +111,25 @@ describe('cds_test', ()=>{
   })
 
 
+  describe ('binary data', ()=> {
+
+    it('should send Buffer bodies as-is and receive octet-stream as Buffer', async () => {
+      const { POST } = test
+      // PNG magic header bytes as sample binary payload
+      const payload = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+      const { data, headers, status } = await POST('/echo-binary', payload, {
+        headers: { 'Content-Type': 'application/octet-stream' },
+        responseType: 'arraybuffer',
+      })
+      expect(status).to.equal(200)
+      expect(headers['content-type']).to.match(/application\/octet-stream/)
+      expect(Buffer.isBuffer(data)).to.equal(true)
+      expect(data.equals(payload)).to.equal(true)
+    })
+
+  })
+
+
   describe ('logs', ()=> {
 
     let log = test.log()


### PR DESCRIPTION
Currently, the `naxios` implementation serializes Buffer request bodies with `JSON.stringify()` instead of sending the raw bytes. This breaks binary uploads and diverges from real axios behavior. Since we removed axios from the `@cap-js/attachments` plugin, we had to work around this with a local patch, but the correct fix belongs in cds-test itself. 